### PR TITLE
Added emulator for testing with docker/compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The `magellan` CLI tool is a Redfish-based, board management controller (BMC) di
 
 ## Getting Started
 
-[Build](#building) and [run on bare metal](#running-the-tool) or run and test with Docker using the [latest prebuilt image](#running-with-docker).
+[Build](#building) and [run on bare metal](#running-the-tool) or run and test with Docker using the [latest prebuilt image](#running-with-docker). For quick testing, the repository integrates a Redfish emulator that can be ran by executing the `emulator/setup.sh` script or running `make emulator`.
 
 ## Building
 

--- a/emulator/Dockerfile
+++ b/emulator/Dockerfile
@@ -1,0 +1,53 @@
+FROM alpine:latest as base
+
+COPY src/requirements.txt /app/requirements.txt
+
+USER root
+
+RUN apk -U upgrade
+RUN apk add --no-cache tini bash
+RUN apk add --no-cache --update \
+        build-base \
+        python3 \
+        python3-dev \
+        py3-pip \
+        openssl \
+        openssl-dev \
+        libffi-dev \
+        gcc \
+        musl-dev \
+        cargo \
+        curl \
+        --force-missing-repositories
+
+# added python venv for MacOS builds with brew
+RUN python3 -m venv ./env \
+    && chmod 777 -R ./env \
+    && ./env/bin/activate
+RUN ./env/bin/python3 -m pip install --upgrade \
+        pip \
+        setuptools \
+    && ./env/bin/python3 -m pip install wheel \
+    && ./env/bin/python3 -m pip install -r /app/requirements.txt
+RUN apk del \
+        build-base \
+        gcc \
+        python3-dev \
+        openssl-dev \
+        libffi-dev \
+        musl-dev \
+        cargo
+
+# Insert our emulator extentions
+COPY src /app
+COPY mockups /app/api_emulator/redfish/static
+
+EXPOSE 5000
+ENV MOCKUPFOLDER="public-rackmount1"
+ENV AUTH_CONFIG=""
+ENV PORT=5000
+ENV XNAME="x3000c0s0b0"
+ENV MAC_SCHEMA=""
+WORKDIR /app
+ENTRYPOINT ["/env/bin/python3"]
+CMD ["emulator.py"]

--- a/emulator/rf-emulator.yml
+++ b/emulator/rf-emulator.yml
@@ -1,0 +1,26 @@
+networks:
+  internal:
+
+volumes:
+  emulator:
+
+services:
+  emulator:
+    image: openchami-rie:latest
+    container_name: rf-emulator
+    environment:
+      BMC_PORT: 5000
+      MOCKUPFOLDER: EX235a
+      AUTH_CONFIG: "root:root_password:Administrator"
+    volumes:
+      - ./rf-emulator/mockups:/mockups
+    ports:
+      - 5000:443
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://127.0.0.1:5000"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+

--- a/emulator/setup.sh
+++ b/emulator/setup.sh
@@ -1,0 +1,12 @@
+#/bin/sh
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# clone the CSM redfish emulator if needed
+if [ ! -d ${script_dir}/rf-emulator ]; then
+	git clone https://github.com/Cray-HPE/csm-redfish-interface-emulator ${script_dir}/rf-emulator
+fi
+
+# build docker image and run with docker compose
+docker build -t openchami-rie:latest -f ${script_dir}/Dockerfile ${script_dir}/rf-emulator
+docker compose -f ${script_dir}/rf-emulator.yml up


### PR DESCRIPTION
Addresses issue #38. It currently adds the CSM redfish emulator, but can be changed later to include more mockups. This PR should not have an impact on anything else related to the project.