### PR TITLE
Added initial tests for API and compatibility coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 magellan
 emulator/rf-emulator
 **/*.db
+<<<<<<< HEAD
 **.tar.gz
 **.tar.zst
 **.part
+=======
+dist/*
+**coverage.out**
+>>>>>>> 4b062dd (Updated .gitignore)

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,8 @@
 magellan
 emulator/rf-emulator
 **/*.db
-<<<<<<< HEAD
 **.tar.gz
 **.tar.zst
 **.part
-=======
 dist/*
 **coverage.out**
->>>>>>> 4b062dd (Updated .gitignore)

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ inst: ## go install tools
 	go install github.com/goreleaser/goreleaser@v1.18.2
 	go install github.com/cpuguy83/go-md2man/v2@latest
 
-.PHONY: goreleaser
+.PHONY: releaser
 release: ## goreleaser build
 	$(call print-target)
 	$(GOPATH)/bin/goreleaser build --clean --single-target --snapshot

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ inst: ## go install tools
 	$(call print-target)
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
-	go install github.com/goreleaser/goreleaser@v1.18.2
+	go install github.com/goreleaser/goreleaser/v2@v2.3.2
 	go install github.com/cpuguy83/go-md2man/v2@latest
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,9 @@ lint: ## golangci-lint
 .PHONY: test
 test: ## go test
 	$(call print-target)
-	go test -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./... ./...
+	./emulator/setup.sh &
+	sleep 10
+	go test -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./... tests/api_test.go tests/compatibility_test.go
 	go tool cover -html=coverage.out -o coverage.html
 
 .PHONY: diff

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ inst: ## go install tools
 	go install github.com/goreleaser/goreleaser@v1.18.2
 	go install github.com/cpuguy83/go-md2man/v2@latest
 
-.PHONY: releaser
+.PHONY: release
 release: ## goreleaser build
 	$(call print-target)
 	$(GOPATH)/bin/goreleaser build --clean --single-target --snapshot

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-
 )
 
 require (

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"fmt"
+	"time"
+)
+
+// CheckUntil regularly check a predicate until it's true or time out is reached.
+func CheckUntil(interval time.Duration, timeout time.Duration, predicate func() (bool, error)) error {
+	timeoutCh := time.After(timeout)
+
+	for {
+		select {
+		case <-time.After(interval):
+			predTrue, err := predicate()
+			if predTrue {
+				return nil
+			}
+
+			if err != nil {
+				return err
+			}
+		case <-timeoutCh:
+			return fmt.Errorf("timeout of %ds reached", int64(timeout/time.Second))
+		}
+	}
+}

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -60,7 +60,7 @@ func TestScanAndCollect(t *testing.T) {
 	// }
 
 	// try and run a "scan" with the emulator
-	command = fmt.Sprintf("%s scan https://172.23.0.2 --port 5000 --cache %s", *exePath, tempDir)
+	command = fmt.Sprintf("%s scan https://127.0.0.1 --port 5000 --cache %s", *exePath, tempDir)
 	cmd = exec.Command("bash", "-c", command)
 	cmd.Stdout = &buf
 	err = cmd.Run()
@@ -184,7 +184,7 @@ func TestGofishFunctions(t *testing.T) {
 // and calling GenerateHostsWithSubnet().
 func TestGenerateHosts(t *testing.T) {
 	var (
-		subnet     = "172.23.0.0"
+		subnet     = "127.0.0.1"
 		subnetMask = &net.IPMask{255, 255, 255, 0}
 		ports      = []int{443}
 		scheme     = "https"
@@ -255,7 +255,7 @@ func waitUntilEmulatorIsReady() error {
 	)
 	err = util.CheckUntil(interval, timeout, func() (bool, error) {
 		// send request to host until we get expected response
-		res, _, err := client.MakeRequest(testClient, "https://172.23.0.2:5000/redfish/v1/", http.MethodGet, body, header)
+		res, _, err := client.MakeRequest(testClient, "https://127.0.0.1:5000/redfish/v1/", http.MethodGet, body, header)
 		if err != nil {
 			return false, fmt.Errorf("failed to make request to emulator: %w", err)
 		}

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -146,6 +146,17 @@ func TestListCommand(t *testing.T) {
 func TestUpdateCommand(t *testing.T) {
 	// TODO: add test that does a Redfish simple update checking it success and
 	// failure points
+	var (
+		cmd    *exec.Cmd
+		err    error
+		output []byte
+	)
+	// set up temporary directory
+	cmd = exec.Command("bash", "-c", fmt.Sprintf("%s list", *exePath))
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to run 'list' command: %v", err)
+	}
 }
 
 func TestGofishFunctions(t *testing.T) {

--- a/tests/api_test.go
+++ b/tests/api_test.go
@@ -8,10 +8,14 @@
 package tests
 
 import (
+	"fmt"
+	"net"
+	"os/exec"
 	"testing"
 
+	"flag"
+
 	magellan "github.com/OpenCHAMI/magellan/internal"
-	"github.com/rs/zerolog/log"
 )
 
 var (
@@ -29,33 +33,114 @@ var (
 		DisableProbing: false,
 		Verbose:        false,
 	}
+	exePath = flag.String("exe", "./magellan", "path to 'magellan' binary executable")
+	emuPath = flag.String("emu", "./emulator/setup.sh", "path to emulator 'setup.sh' script")
 )
 
+func runEmulator() {}
+
 func TestScanAndCollect(t *testing.T) {
-	// do a scan on the emulator cluster with probing disabled and check results
-	results := magellan.ScanForAssets(scanParams)
-	if len(results) <= 0 {
-		t.Fatal("expected to find at least one BMC node, but found none")
-	}
-	// do a scan on the emulator cluster with probing enabled
-	results = magellan.ScanForAssets(scanParams)
-	if len(results) <= 0 {
-		t.Fatal("expected to find at least one BMC node, but found none")
+	var (
+		err     error
+		emuErr  error
+		output  []byte
+		tempDir = t.TempDir()
+		command string
+	)
+
+	// try and start the emulator in the background if arg passed
+	if *emuPath != "" {
+		t.Parallel()
+		t.Run("emulator", func(t *testing.T) {
+			_, emuErr = exec.Command("bash", "-c", *emuPath).CombinedOutput()
+			if emuErr != nil {
+				t.Fatalf("failed to start emulator: %v", emuErr)
+			}
+		})
 	}
 
-	// do a collect on the emulator cluster to collect Redfish info
-	err := magellan.CollectInventory(&results, &magellan.CollectParams{})
+	// try and run a "scan" with the emulator
+	command = fmt.Sprintf("%s scan --subnet 127.0.0.1 --subnet-mask 255.255.255.0 --cache %s", exePath, tempDir)
+	output, err = exec.Command("bash", "-c", command).CombinedOutput()
 	if err != nil {
-		log.Error().Err(err).Msg("failed to collect inventory")
+		t.Fatalf("failed to run 'scan' command: %v", err)
 	}
+
+	// make sure that the expected output is not empty
+	if len(output) <= 0 {
+		t.Fatalf("expected the 'scan' output to not be empty")
+	}
+
+	// try and run a "collect" with the emulator
+	command = fmt.Sprintf("%s collect --username root --password root_password --cache %s", exePath, tempDir)
+	output, err = exec.Command("bash", "-c", command).CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to run 'collect' command: %v", err)
+	}
+
+	// make sure that the output is not empty
+	if len(output) <= 0 {
+		t.Fatalf("expected the 'collect' output to not be empty")
+	}
+
+	// TODO: check for at least one System/EthernetInterface that we know should exist
 }
 
 func TestCrawlCommand(t *testing.T) {
-	// TODO: add test to check the crawl command's behavior
+	var (
+		err     error
+		emuErr  error
+		output  []byte
+		command string
+	)
+
+	// try and start the emulator in the background if arg passed
+	if *emuPath != "" {
+		t.Parallel()
+		t.Run("emulator", func(t *testing.T) {
+			_, emuErr = exec.Command("bash", "-c", *emuPath).CombinedOutput()
+			if emuErr != nil {
+				t.Fatalf("failed to start emulator: %v", emuErr)
+			}
+		})
+	}
+
+	// try and run a "collect" with the emulator
+	command = fmt.Sprintf("%s crawl --username root --password root_password -i", exePath)
+	output, err = exec.Command("bash", "-c", command).CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to run 'crawl' command: %v", err)
+	}
+
+	// make sure that the output is not empty
+	if len(output) <= 0 {
+		t.Fatalf("expected the 'crawl' output to not be empty")
+	}
+
 }
 
 func TestListCommand(t *testing.T) {
-	// TODO: add test to check the list command's output
+	// TODO: need magellan binary to test command
+	var (
+		cmd    *exec.Cmd
+		err    error
+		output []byte
+	)
+
+	// set up the test
+
+	// set up temporary directory
+	cmd = exec.Command("bash", "-c", fmt.Sprintf("%s list", *exePath))
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to run 'list' command: %v", err)
+	}
+
+	// make sure that the output is not empty
+	if len(output) <= 0 {
+		t.Fatalf("expected the 'list' output to not be empty")
+	}
+
 }
 
 func TestUpdateCommand(t *testing.T) {
@@ -70,4 +155,26 @@ func TestGofishFunctions(t *testing.T) {
 
 func TestGenerateHosts(t *testing.T) {
 	// TODO: add test to generate hosts using a collection of subnets/masks
+	t.Run("generate-hosts.1", func(t *testing.T) {
+		var (
+			subnet     = "172.16.0.0"
+			subnetMask = &net.IPMask{255, 255, 255, 0}
+			ports      = []int{443}
+			scheme     = "https"
+			hosts      = [][]string{}
+		)
+		hosts = magellan.GenerateHostsWithSubnet(subnet, subnetMask, ports, scheme)
+	})
+
+	t.Run("generate-hosts.2", func(t *testing.T) {
+		var (
+			subnet     = "127.0.0.1"
+			subnetMask = &net.IPMask{255, 255, 255, 0}
+			ports      = []int{443, 5000}
+			scheme     = "https"
+			hosts      = [][]string{}
+		)
+		hosts = magellan.GenerateHostsWithSubnet(subnet, subnetMask, ports, scheme)
+	})
+
 }

--- a/tests/compatibility_test.go
+++ b/tests/compatibility_test.go
@@ -7,6 +7,7 @@
 package tests
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -18,9 +19,9 @@ import (
 )
 
 var (
-	host     = flag.String("host", "localhost", "set the BMC host")
-	username = flag.String("username", "", "set the BMC username used for the tests")
-	password = flag.String("password", "", "set the BMC password used for the tests")
+	host     = flag.String("host", "https://172.23.0.2:5000", "set the BMC host")
+	username = flag.String("username", "root", "set the BMC username used for the tests")
+	password = flag.String("password", "root_password", "set the BMC password used for the tests")
 )
 
 func checkResponse(res *http.Response, b []byte) error {
@@ -35,7 +36,7 @@ func checkResponse(res *http.Response, b []byte) error {
 	}
 
 	// make sure the response body is in a valid JSON format
-	if json.Valid(b) {
+	if !json.Valid(b) {
 		return fmt.Errorf("expected response body to be valid JSON")
 	}
 	return nil
@@ -44,11 +45,24 @@ func checkResponse(res *http.Response, b []byte) error {
 // Simple test to fetch the base Redfish URL and assert a 200 OK response.
 func TestRedfishV1ServiceRootAvailability(t *testing.T) {
 	var (
-		url     = fmt.Sprintf("%s/redfish/v1", *host)
-		body    = []byte{}
-		headers = map[string]string{}
+		url        = fmt.Sprintf("%s/redfish/v1/", *host)
+		body       = []byte{}
+		headers    = map[string]string{}
+		testClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+		err error
 	)
-	res, b, err := client.MakeRequest(nil, url, http.MethodGet, body, headers)
+
+	// set up the emulator to run before test
+	err = waitUntilEmulatorIsReady()
+	if err != nil {
+		t.Fatalf("failed while waiting for emulator: %v", err)
+	}
+
+	res, b, err := client.MakeRequest(testClient, url, http.MethodGet, body, headers)
 	if err != nil {
 		t.Fatalf("failed to make request to BMC node: %v", err)
 	}
@@ -63,19 +77,36 @@ func TestRedfishV1ServiceRootAvailability(t *testing.T) {
 // Simple test to ensure an expected Redfish version minimum requirement.
 func TestRedfishV1Version(t *testing.T) {
 	var (
-		url     string            = fmt.Sprintf("%s/redfish/v1", *host)
-		body    client.HTTPBody   = []byte{}
-		headers client.HTTPHeader = map[string]string{}
-		err     error
+		url        string            = fmt.Sprintf("%s/redfish/v1/", *host)
+		body       client.HTTPBody   = []byte{}
+		headers    client.HTTPHeader = map[string]string{}
+		testClient                   = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+		root map[string]any
+		err  error
 	)
 
-	res, b, err := client.MakeRequest(nil, url, http.MethodGet, body, headers)
+	res, b, err := client.MakeRequest(testClient, url, http.MethodGet, body, headers)
 	if err != nil {
 		t.Fatalf("failed to make request to BMC node: %v", err)
 	}
 	err = checkResponse(res, b)
 	if err != nil {
 		t.Fatalf("failed to check response for redfish version: %v", err)
+	}
+
+	// check the "RedfishVersion" from service root
+	err = json.Unmarshal(b, &root)
+	if err != nil {
+		t.Fatalf("failed to unmarshal redfish response: %v", err)
+	}
+
+	_, ok := root["RedfishVersion"]
+	if !ok {
+		t.Fatalf("failed to get 'RedfishVersion' from service root")
 	}
 }
 
@@ -87,6 +118,12 @@ func TestExpectedOutput(t *testing.T) {
 	// make sure what have a valid host
 	if host == nil {
 		t.Fatal("invalid host (host is nil)")
+	}
+
+	// set up the emulator to run before test
+	err := waitUntilEmulatorIsReady()
+	if err != nil {
+		t.Fatalf("failed while waiting for emulator: %v", err)
 	}
 
 	systems, err := crawler.CrawlBMC(
@@ -116,9 +153,6 @@ func TestExpectedOutput(t *testing.T) {
 		// we expect each system to have at least one of each interface
 		if len(system.EthernetInterfaces) <= 0 {
 			t.Errorf("no ethernet interfaces found for system '%s'", system.Name)
-		}
-		if len(system.NetworkInterfaces) <= 0 {
-			t.Errorf("no network interfaces found for system '%s'", system.Name)
 		}
 	}
 }

--- a/tests/compatibility_test.go
+++ b/tests/compatibility_test.go
@@ -50,10 +50,13 @@ func TestRedfishV1ServiceRootAvailability(t *testing.T) {
 	)
 	res, b, err := client.MakeRequest(nil, url, http.MethodGet, body, headers)
 	if err != nil {
-		t.Fatalf("failed to make request to BMC node: %w", err)
+		t.Fatalf("failed to make request to BMC node: %v", err)
 	}
 
 	err = checkResponse(res, b)
+	if err != nil {
+		t.Fatalf("failed to check response for redfish service root: %v", err)
+	}
 
 }
 
@@ -68,9 +71,12 @@ func TestRedfishV1Version(t *testing.T) {
 
 	res, b, err := client.MakeRequest(nil, url, http.MethodGet, body, headers)
 	if err != nil {
-		t.Fatalf("failed to make request to BMC node: %w", err)
+		t.Fatalf("failed to make request to BMC node: %v", err)
 	}
 	err = checkResponse(res, b)
+	if err != nil {
+		t.Fatalf("failed to check response for redfish version: %v", err)
+	}
 }
 
 // Crawls a BMC node and checks that we're able to query certain properties

--- a/tests/compatibility_test.go
+++ b/tests/compatibility_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	host     = flag.String("host", "https://172.23.0.2:5000", "set the BMC host")
+	host     = flag.String("host", "https://127.0.0.1:5000", "set the BMC host")
 	username = flag.String("username", "root", "set the BMC username used for the tests")
 	password = flag.String("password", "root_password", "set the BMC password used for the tests")
 )


### PR DESCRIPTION
This PR adds an initial series of tests to make Magellan more reliable when using on different systems and to pin point areas that need improvement. These tests focuses primarily on two specific areas:

- regression tests to ensure that Magellan's API works correct with static hardware (i.e. the emulator)
- compatibility tests to ensure Magellan works when trying out different hardware and dynamic configurations

The API regression tests are meant to ensure that the frequent changes made to the project doesn't break the tool. This should ease a lot of the issues we've had before when needing to add or expand features and not getting the expected behaviors we wanted. The compatibility tests are meant to ease the transition of using Magellan on new hardware and make the process less painful. It should also help the debugging process when things *do* go wrong to find exactly where a problem is occurring. These tests are *very likely* to be expanded as more hardware is tested to cover more Redfish implementations and use cases.

Ideally at some point, the tests should be integrated into an automated CI work flow that requires that all tests pass before merging new PRs into the `main` branch.