### PR TITLE
Export commands for external use

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -17,7 +17,7 @@ import (
 // The `collect` command fetches data from a collection of BMC nodes.
 // This command should be ran after the `scan` to find available hosts
 // on a subnet.
-var collectCmd = &cobra.Command{
+var CollectCmd = &cobra.Command{
 	Use:   "collect",
 	Short: "Collect system information by interrogating BMC node",
 	Long: "Send request(s) to a collection of hosts running Redfish services found stored from the 'scan' in cache.\n" +
@@ -75,28 +75,28 @@ var collectCmd = &cobra.Command{
 
 func init() {
 	currentUser, _ = user.Current()
-	collectCmd.PersistentFlags().StringVar(&host, "host", "", "Set the URI to the SMD root endpoint")
-	collectCmd.PersistentFlags().StringVar(&username, "username", "", "Set the BMC user")
-	collectCmd.PersistentFlags().StringVar(&password, "password", "", "Set the BMC password")
-	collectCmd.PersistentFlags().StringVar(&scheme, "scheme", "https", "Set the scheme used to query")
-	collectCmd.PersistentFlags().StringVar(&protocol, "protocol", "tcp", "Set the protocol used to query")
-	collectCmd.PersistentFlags().StringVarP(&outputPath, "output", "o", fmt.Sprintf("/tmp/%smagellan/inventory/", currentUser.Username+"/"), "Set the path to store collection data")
-	collectCmd.PersistentFlags().BoolVar(&forceUpdate, "force-update", false, "Set flag to force update data sent to SMD")
-	collectCmd.PersistentFlags().StringVar(&cacertPath, "cacert", "", "Path to CA cert. (defaults to system CAs)")
+	CollectCmd.PersistentFlags().StringVar(&host, "host", "", "Set the URI to the SMD root endpoint")
+	CollectCmd.PersistentFlags().StringVar(&username, "username", "", "Set the BMC user")
+	CollectCmd.PersistentFlags().StringVar(&password, "password", "", "Set the BMC password")
+	CollectCmd.PersistentFlags().StringVar(&scheme, "scheme", "https", "Set the scheme used to query")
+	CollectCmd.PersistentFlags().StringVar(&protocol, "protocol", "tcp", "Set the protocol used to query")
+	CollectCmd.PersistentFlags().StringVarP(&outputPath, "output", "o", fmt.Sprintf("/tmp/%smagellan/inventory/", currentUser.Username+"/"), "Set the path to store collection data")
+	CollectCmd.PersistentFlags().BoolVar(&forceUpdate, "force-update", false, "Set flag to force update data sent to SMD")
+	CollectCmd.PersistentFlags().StringVar(&cacertPath, "cacert", "", "Path to CA cert. (defaults to system CAs)")
 
 	// set flags to only be used together
-	collectCmd.MarkFlagsRequiredTogether("username", "password")
+	CollectCmd.MarkFlagsRequiredTogether("username", "password")
 
 	// bind flags to config properties
-	checkBindFlagError(viper.BindPFlag("collect.host", collectCmd.Flags().Lookup("host")))
-	checkBindFlagError(viper.BindPFlag("collect.username", collectCmd.Flags().Lookup("username")))
-	checkBindFlagError(viper.BindPFlag("collect.password", collectCmd.Flags().Lookup("password")))
-	checkBindFlagError(viper.BindPFlag("collect.scheme", collectCmd.Flags().Lookup("scheme")))
-	checkBindFlagError(viper.BindPFlag("collect.protocol", collectCmd.Flags().Lookup("protocol")))
-	checkBindFlagError(viper.BindPFlag("collect.output", collectCmd.Flags().Lookup("output")))
-	checkBindFlagError(viper.BindPFlag("collect.force-update", collectCmd.Flags().Lookup("force-update")))
-	checkBindFlagError(viper.BindPFlag("collect.cacert", collectCmd.Flags().Lookup("cacert")))
-	checkBindFlagError(viper.BindPFlags(collectCmd.Flags()))
+	checkBindFlagError(viper.BindPFlag("collect.host", CollectCmd.Flags().Lookup("host")))
+	checkBindFlagError(viper.BindPFlag("collect.username", CollectCmd.Flags().Lookup("username")))
+	checkBindFlagError(viper.BindPFlag("collect.password", CollectCmd.Flags().Lookup("password")))
+	checkBindFlagError(viper.BindPFlag("collect.scheme", CollectCmd.Flags().Lookup("scheme")))
+	checkBindFlagError(viper.BindPFlag("collect.protocol", CollectCmd.Flags().Lookup("protocol")))
+	checkBindFlagError(viper.BindPFlag("collect.output", CollectCmd.Flags().Lookup("output")))
+	checkBindFlagError(viper.BindPFlag("collect.force-update", CollectCmd.Flags().Lookup("force-update")))
+	checkBindFlagError(viper.BindPFlag("collect.cacert", CollectCmd.Flags().Lookup("cacert")))
+	checkBindFlagError(viper.BindPFlags(CollectCmd.Flags()))
 
-	rootCmd.AddCommand(collectCmd)
+	rootCmd.AddCommand(CollectCmd)
 }

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -14,7 +14,7 @@ import (
 // The `crawl` command walks a collection of Redfish endpoints to collect
 // specfic inventory detail. This command only expects host names and does
 // not require a scan to be performed beforehand.
-var crawlCmd = &cobra.Command{
+var CrawlCmd = &cobra.Command{
 	Use:   "crawl [uri]",
 	Short: "Crawl a single BMC for inventory information",
 	Long: "Crawl a single BMC for inventory information. This command does NOT store information\n" +
@@ -57,13 +57,13 @@ var crawlCmd = &cobra.Command{
 }
 
 func init() {
-	crawlCmd.Flags().StringP("username", "u", "", "Set the username for the BMC")
-	crawlCmd.Flags().StringP("password", "p", "", "Set the password for the BMC")
-	crawlCmd.Flags().BoolP("insecure", "i", false, "Ignore SSL errors")
+	CrawlCmd.Flags().StringP("username", "u", "", "Set the username for the BMC")
+	CrawlCmd.Flags().StringP("password", "p", "", "Set the password for the BMC")
+	CrawlCmd.Flags().BoolP("insecure", "i", false, "Ignore SSL errors")
 
-	checkBindFlagError(viper.BindPFlag("crawl.username", crawlCmd.Flags().Lookup("username")))
-	checkBindFlagError(viper.BindPFlag("crawl.password", crawlCmd.Flags().Lookup("password")))
-	checkBindFlagError(viper.BindPFlag("crawl.insecure", crawlCmd.Flags().Lookup("insecure")))
+	checkBindFlagError(viper.BindPFlag("crawl.username", CrawlCmd.Flags().Lookup("username")))
+	checkBindFlagError(viper.BindPFlag("crawl.password", CrawlCmd.Flags().Lookup("password")))
+	checkBindFlagError(viper.BindPFlag("crawl.insecure", CrawlCmd.Flags().Lookup("insecure")))
 
-	rootCmd.AddCommand(crawlCmd)
+	rootCmd.AddCommand(CrawlCmd)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,7 +19,7 @@ var (
 // The `list` command provides an easy way to show what was found
 // and stored in a cache database from a scan. The data that's stored
 // is what is consumed by the `collect` command with the --cache flag.
-var listCmd = &cobra.Command{
+var ListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List information stored in cache from a scan",
 	Long: "Prints all of the host and associated data found from performing a scan.\n" +
@@ -55,7 +55,7 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
-	listCmd.Flags().StringVar(&format, "format", "", "Set the output format (json|default)")
-	listCmd.Flags().BoolVar(&showCache, "cache-info", false, "Show cache information and exit")
-	rootCmd.AddCommand(listCmd)
+	ListCmd.Flags().StringVar(&format, "format", "", "Set the output format (json|default)")
+	ListCmd.Flags().BoolVar(&showCache, "cache-info", false, "Show cache information and exit")
+	rootCmd.AddCommand(ListCmd)
 }

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -32,7 +32,7 @@ var (
 //
 // See the `ScanForAssets()` function in 'internal/scan.go' for details
 // related to the implementation.
-var scanCmd = &cobra.Command{
+var ScanCmd = &cobra.Command{
 	Use:   "scan urls...",
 	Short: "Scan to discover BMC nodes on a network",
 	Long: "Perform a net scan by attempting to connect to each host and port specified and getting a response.\n" +
@@ -175,23 +175,23 @@ var scanCmd = &cobra.Command{
 
 func init() {
 	// scanCmd.Flags().StringSliceVar(&hosts, "host", []string{}, "set additional hosts to scan")
-	scanCmd.Flags().StringSliceVar(&hosts, "host", nil, "Add individual hosts to scan. (example: https://my.bmc.com:5000; same as using positional args)")
-	scanCmd.Flags().IntSliceVar(&ports, "port", nil, "Adds additional ports to scan for each host with unspecified ports.")
-	scanCmd.Flags().StringVar(&scheme, "scheme", "https", "Set the default scheme to use if not specified in host URI. (default is 'https')")
-	scanCmd.Flags().StringVar(&protocol, "protocol", "tcp", "Set the default protocol to use in scan. (default is 'tcp')")
-	scanCmd.Flags().StringSliceVar(&subnets, "subnet", nil, "Add additional hosts from specified subnets to scan.")
-	scanCmd.Flags().IPMaskVar(&subnetMask, "subnet-mask", net.IPv4Mask(255, 255, 255, 0), "Set the default subnet mask to use for with all subnets not using CIDR notation.")
-	scanCmd.Flags().BoolVar(&disableProbing, "disable-probing", false, "Disable probing found assets for Redfish service(s) running on BMC nodes")
-	scanCmd.Flags().BoolVar(&disableCache, "disable-cache", false, "Disable saving found assets to a cache database specified with 'cache' flag")
+	ScanCmd.Flags().StringSliceVar(&hosts, "host", nil, "Add individual hosts to scan. (example: https://my.bmc.com:5000; same as using positional args)")
+	ScanCmd.Flags().IntSliceVar(&ports, "port", nil, "Adds additional ports to scan for each host with unspecified ports.")
+	ScanCmd.Flags().StringVar(&scheme, "scheme", "https", "Set the default scheme to use if not specified in host URI. (default is 'https')")
+	ScanCmd.Flags().StringVar(&protocol, "protocol", "tcp", "Set the default protocol to use in scan. (default is 'tcp')")
+	ScanCmd.Flags().StringSliceVar(&subnets, "subnet", nil, "Add additional hosts from specified subnets to scan.")
+	ScanCmd.Flags().IPMaskVar(&subnetMask, "subnet-mask", net.IPv4Mask(255, 255, 255, 0), "Set the default subnet mask to use for with all subnets not using CIDR notation.")
+	ScanCmd.Flags().BoolVar(&disableProbing, "disable-probing", false, "Disable probing found assets for Redfish service(s) running on BMC nodes")
+	ScanCmd.Flags().BoolVar(&disableCache, "disable-cache", false, "Disable saving found assets to a cache database specified with 'cache' flag")
 
-	checkBindFlagError(viper.BindPFlag("scan.hosts", scanCmd.Flags().Lookup("host")))
-	checkBindFlagError(viper.BindPFlag("scan.ports", scanCmd.Flags().Lookup("port")))
-	checkBindFlagError(viper.BindPFlag("scan.scheme", scanCmd.Flags().Lookup("scheme")))
-	checkBindFlagError(viper.BindPFlag("scan.protocol", scanCmd.Flags().Lookup("protocol")))
-	checkBindFlagError(viper.BindPFlag("scan.subnets", scanCmd.Flags().Lookup("subnet")))
-	checkBindFlagError(viper.BindPFlag("scan.subnet-masks", scanCmd.Flags().Lookup("subnet-mask")))
-	checkBindFlagError(viper.BindPFlag("scan.disable-probing", scanCmd.Flags().Lookup("disable-probing")))
-	checkBindFlagError(viper.BindPFlag("scan.disable-cache", scanCmd.Flags().Lookup("disable-cache")))
+	checkBindFlagError(viper.BindPFlag("scan.hosts", ScanCmd.Flags().Lookup("host")))
+	checkBindFlagError(viper.BindPFlag("scan.ports", ScanCmd.Flags().Lookup("port")))
+	checkBindFlagError(viper.BindPFlag("scan.scheme", ScanCmd.Flags().Lookup("scheme")))
+	checkBindFlagError(viper.BindPFlag("scan.protocol", ScanCmd.Flags().Lookup("protocol")))
+	checkBindFlagError(viper.BindPFlag("scan.subnets", ScanCmd.Flags().Lookup("subnet")))
+	checkBindFlagError(viper.BindPFlag("scan.subnet-masks", ScanCmd.Flags().Lookup("subnet-mask")))
+	checkBindFlagError(viper.BindPFlag("scan.disable-probing", ScanCmd.Flags().Lookup("disable-probing")))
+	checkBindFlagError(viper.BindPFlag("scan.disable-cache", ScanCmd.Flags().Lookup("disable-cache")))
 
-	rootCmd.AddCommand(scanCmd)
+	rootCmd.AddCommand(ScanCmd)
 }


### PR DESCRIPTION
This PR exports the `scan`, `collect`, `list`, and `update` commands to be added to another cobra CLI like the `ochami` tool. 