### PR TITLE
Add "default" secret lookup in `LocalStore` for `crawl` and `collect` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,16 +254,16 @@ magellan collect \
   --password $default_bmc_password
 ```
 
-If you pass agruments with the `--username/--password` flags, they will be used as a fallback if no credentials are found in the store. However, the secret store credentials are always used first if they exists.
+If you pass arguments with the `--username/--password` flags, the arguments will override all credentials set in the secret store for each flag. However, it is possible only override a single flag (e.g. `magellan collect --username`).
 
 > [!NOTE]
 > Make sure that the `secretID` is EXACTLY as show with `magellan list`. Otherwise, `magellan` will not be able to do the lookup from the secret store correctly.
 
 > [!TIP]
-> You can set default fallback credentials by storing a secret with the `secretID` of "default". This is used if no `secretID` is found in the local store for the specified host. Otherwise, the `--username/--password` arguments are used.
+> You can set default fallback credentials by storing a secret with the `secretID` of "default". This is used if no `secretID` is found in the local store for the specified host. This is useful when you want to set a username and password that is the same for all BMCs with the exception of the ones specified.
 > ```bash
 > magellan secrets default $username:$password
->
+> ```
 
 ### Starting the Emulator
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ If you pass agruments with the `--username/--password` flags, they will be used 
 > [!NOTE]
 > Make sure that the `secretID` is EXACTLY as show with `magellan list`. Otherwise, `magellan` will not be able to do the lookup from the secret store correctly.
 
+> [!TIP]
+> You can set default fallback credentials by storing a secret with the `secretID` of "default". This is used if no `secretID` is found in the local store for the specified host. Otherwise, the `--username/--password` arguments are used.
+> ```bash
+> magellan secrets default $username:$password
+>
+
 ### Starting the Emulator
 
 This repository includes a quick and dirty way to test `magellan` using a Redfish emulator with little to no effort to get running.

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -95,15 +95,17 @@ var CollectCmd = &cobra.Command{
 			// if we have CLI flags set, then we want to override default stored creds
 			if username != "" && password != "" {
 				// finally, use the CLI arguments passed instead
+				log.Info().Msg("...using provided arguments for credentials")
 				store = secrets.NewStaticStore(username, password)
 			} else {
 				// try and get a default *stored* username/password
-				secret, err := store.GetSecretByID("default")
+				secret, err := store.GetSecretByID(secrets.DEFAULT_KEY)
 				if err != nil {
 					// no default found, so use CLI arguments
-					log.Warn().Err(err).Msg("no default credentials found")
+					log.Warn().Err(err).Msg("failed to get default credentials...")
 				} else {
 					// found default values in local store so use them
+					log.Info().Msg("...using default store for credentials")
 					var creds crawler.BMCUsernamePassword
 					err = json.Unmarshal([]byte(secret), &creds)
 					if err != nil {

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -19,17 +19,19 @@ import (
 // This command should be ran after the `scan` to find available hosts
 // on a subnet.
 var CollectCmd = &cobra.Command{
-	Use:   "collect",
+	Use: "collect",
+	Example: `  // basic collect after scan without making a follow-up request
+  magellan collect --cache ./assets.db --cacert ochami.pem -o ./logs -t 30
+
+  // set username and password for all nodes and make request to specified host
+  magellan collect --host https://smd.openchami.cluster -u $bmc_username -p $bmc_password
+
+  // run a collect using secrets manager with fallback username and password
+  export MASTER_KEY=$(magellan secrets generatekey)
+  magellan secrets store $node_creds_json -f nodes.json
+  magellan collect --host https://smd.openchami.cluster -u $fallback_bmc_username -p $fallback_bmc_password`,
 	Short: "Collect system information by interrogating BMC node",
-	Long: "Send request(s) to a collection of hosts running Redfish services found stored from the 'scan' in cache.\n" +
-		"See the 'scan' command on how to perform a scan.\n\n" +
-		"Examples:\n" +
-		"  magellan collect --cache ./assets.db --output ./logs --timeout 30 --cacert cecert.pem\n" +
-		"  magellan collect --host smd.example.com --port 27779 --username $username --password $password\n\n" +
-		// example using `collect`
-		"  export MASTER_KEY=$(magellan secrets generatekey)\n" +
-		"  magellan secrets store $node_creds_json -f nodes.json" +
-		"  magellan collect --host openchami.cluster --username $username --password $password \\\n",
+	Long:  "Send request(s) to a collection of hosts running Redfish services found stored from the 'scan' in cache.\nSee the 'scan' command on how to perform a scan.",
 	Run: func(cmd *cobra.Command, args []string) {
 		// get probe states stored in db from scan
 		scannedResults, err := sqlite.GetScannedAssets(cachePath)
@@ -110,8 +112,6 @@ func init() {
 
 	// bind flags to config properties
 	checkBindFlagError(viper.BindPFlag("collect.host", CollectCmd.Flags().Lookup("host")))
-	checkBindFlagError(viper.BindPFlag("collect.username", CollectCmd.Flags().Lookup("username")))
-	checkBindFlagError(viper.BindPFlag("collect.password", CollectCmd.Flags().Lookup("password")))
 	checkBindFlagError(viper.BindPFlag("collect.scheme", CollectCmd.Flags().Lookup("scheme")))
 	checkBindFlagError(viper.BindPFlag("collect.protocol", CollectCmd.Flags().Lookup("protocol")))
 	checkBindFlagError(viper.BindPFlag("collect.output", CollectCmd.Flags().Lookup("output")))

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -9,7 +9,7 @@ import (
 	urlx "github.com/OpenCHAMI/magellan/internal/url"
 	magellan "github.com/OpenCHAMI/magellan/pkg"
 	"github.com/OpenCHAMI/magellan/pkg/auth"
-	"github.com/OpenCHAMI/magellan/pkg/crawler"
+	"github.com/OpenCHAMI/magellan/pkg/bmc"
 	"github.com/OpenCHAMI/magellan/pkg/secrets"
 	"github.com/cznic/mathutil"
 	"github.com/rs/zerolog/log"
@@ -61,6 +61,59 @@ var CollectCmd = &cobra.Command{
 			concurrency = mathutil.Clamp(len(scannedResults), 1, 10000)
 		}
 
+		// use secret store for BMC credentials, and/or credential CLI flags
+		var store secrets.SecretStore
+		if username != "" && password != "" {
+			// First, try and load credentials from --username and --password if both are set.
+			log.Debug().Msgf("--username and --password specified, using them for BMC credentials")
+			store = secrets.NewStaticStore(username, password)
+		} else {
+			// Alternatively, locate specific credentials (falling back to default) and override those
+			// with --username or --password if either are passed.
+			log.Debug().Msgf("one or both of --username and --password NOT passed, attempting to obtain missing credentials from secret store at %s", secretsFile)
+			if store, err = secrets.OpenStore(secretsFile); err != nil {
+				log.Error().Err(err).Msg("failed to open local secrets store")
+			}
+
+			// Temporarily override username/password of each BMC if one of those
+			// flags is passed. The expectation is that if the flag is specified
+			// on the command line, it should be used.
+			if username != "" {
+				log.Info().Msg("--username passed, temporarily overriding all usernames from secret store with value")
+			}
+			if password != "" {
+				log.Info().Msg("--password passed, temporarily overriding all passwords from secret store with value")
+			}
+			switch s := store.(type) {
+			case *secrets.StaticStore:
+				if username != "" {
+					s.Username = username
+				}
+				if password != "" {
+					s.Password = password
+				}
+			case *secrets.LocalSecretStore:
+				for k, _ := range s.Secrets {
+					if creds, err := bmc.GetBMCCredentials(store, k); err != nil {
+						log.Error().Str("id", k).Err(err).Msg("failed to override BMC credentials")
+					} else {
+						if username != "" {
+							creds.Username = username
+						}
+						if password != "" {
+							creds.Password = password
+						}
+
+						if newCreds, err := json.Marshal(creds); err != nil {
+							log.Error().Str("id", k).Err(err).Msg("failed to override BMC credentials: marshal error")
+						} else {
+							s.StoreSecretByID(k, string(newCreds))
+						}
+					}
+				}
+			}
+		}
+
 		// set the collect parameters from CLI params
 		params := &magellan.CollectParams{
 			URI:         host,
@@ -71,9 +124,7 @@ var CollectCmd = &cobra.Command{
 			OutputPath:  outputPath,
 			ForceUpdate: forceUpdate,
 			AccessToken: accessToken,
-			SecretsFile: secretsFile,
-			Username:    username,
-			Password:    password,
+			SecretStore: store,
 		}
 
 		// show all of the 'collect' parameters being set from CLI if verbose
@@ -81,41 +132,7 @@ var CollectCmd = &cobra.Command{
 			log.Debug().Any("params", params)
 		}
 
-		// load the secrets file to get node credentials by ID (i.e. the BMC node's URI)
-		store, err := secrets.OpenStore(params.SecretsFile)
-		if err != nil {
-			log.Warn().Err(err).Msg("failed to open local store...falling back to default provided arguments")
-			// try and use the `username` and `password` arguments instead
-			store = secrets.NewStaticStore(username, password)
-		}
-
-		// found the store so try to load the creds
-		_, err = store.GetSecretByID(host)
-		if err != nil {
-			// if we have CLI flags set, then we want to override default stored creds
-			if username != "" && password != "" {
-				// finally, use the CLI arguments passed instead
-				log.Info().Msg("...using provided arguments for credentials")
-				store = secrets.NewStaticStore(username, password)
-			} else {
-				// try and get a default *stored* username/password
-				secret, err := store.GetSecretByID(secrets.DEFAULT_KEY)
-				if err != nil {
-					// no default found, so use CLI arguments
-					log.Warn().Err(err).Msg("failed to get default credentials...")
-				} else {
-					// found default values in local store so use them
-					log.Info().Msg("...using default store for credentials")
-					var creds crawler.BMCUsernamePassword
-					err = json.Unmarshal([]byte(secret), &creds)
-					if err != nil {
-						log.Warn().Err(err).Msg("failed to unmarshal default store credentials")
-					}
-				}
-			}
-		}
-
-		_, err = magellan.CollectInventory(&scannedResults, params, store)
+		_, err = magellan.CollectInventory(&scannedResults, params)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to collect data")
 		}
@@ -124,18 +141,15 @@ var CollectCmd = &cobra.Command{
 
 func init() {
 	currentUser, _ = user.Current()
-	CollectCmd.PersistentFlags().StringVar(&host, "host", "", "Set the URI to the SMD root endpoint")
-	CollectCmd.PersistentFlags().StringVarP(&username, "username", "u", "", "Set the master BMC username")
-	CollectCmd.PersistentFlags().StringVarP(&password, "password", "p", "", "Set the master BMC password")
-	CollectCmd.PersistentFlags().StringVar(&secretsFile, "secrets-file", "", "Set path to the node secrets file")
-	CollectCmd.PersistentFlags().StringVar(&scheme, "scheme", "https", "Set the default scheme used to query when not included in URI")
-	CollectCmd.PersistentFlags().StringVar(&protocol, "protocol", "tcp", "Set the protocol used to query")
-	CollectCmd.PersistentFlags().StringVarP(&outputPath, "output", "o", fmt.Sprintf("/tmp/%smagellan/inventory/", currentUser.Username+"/"), "Set the path to store collection data")
-	CollectCmd.PersistentFlags().BoolVar(&forceUpdate, "force-update", false, "Set flag to force update data sent to SMD")
-	CollectCmd.PersistentFlags().StringVar(&cacertPath, "cacert", "", "Set the path to CA cert file. (defaults to system CAs when blank)")
-
-	// set flags to only be used together
-	CollectCmd.MarkFlagsRequiredTogether("username", "password")
+	CollectCmd.Flags().StringVar(&host, "host", "", "Set the URI to the SMD root endpoint")
+	CollectCmd.Flags().StringVarP(&username, "username", "u", "", "Set the master BMC username")
+	CollectCmd.Flags().StringVarP(&password, "password", "p", "", "Set the master BMC password")
+	CollectCmd.Flags().StringVar(&secretsFile, "secrets-file", "", "Set path to the node secrets file")
+	CollectCmd.Flags().StringVar(&scheme, "scheme", "https", "Set the default scheme used to query when not included in URI")
+	CollectCmd.Flags().StringVar(&protocol, "protocol", "tcp", "Set the protocol used to query")
+	CollectCmd.Flags().StringVarP(&outputPath, "output", "o", fmt.Sprintf("/tmp/%smagellan/inventory/", currentUser.Username+"/"), "Set the path to store collection data")
+	CollectCmd.Flags().BoolVar(&forceUpdate, "force-update", false, "Set flag to force update data sent to SMD")
+	CollectCmd.Flags().StringVar(&cacertPath, "cacert", "", "Set the path to CA cert file. (defaults to system CAs when blank)")
 
 	// bind flags to config properties
 	checkBindFlagError(viper.BindPFlag("collect.host", CollectCmd.Flags().Lookup("host")))

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	urlx "github.com/OpenCHAMI/magellan/internal/url"
+	"github.com/OpenCHAMI/magellan/pkg/bmc"
 	"github.com/OpenCHAMI/magellan/pkg/crawler"
 	"github.com/OpenCHAMI/magellan/pkg/secrets"
 	"github.com/spf13/cobra"
@@ -43,60 +44,32 @@ var CrawlCmd = &cobra.Command{
 
 		if username != "" && password != "" {
 			// First, try and load credentials from --username and --password if both are set.
-			log.Debug().Str("uri", uri).Msgf("--username and --password specified, using them for BMC credentials")
+			log.Debug().Str("id", uri).Msgf("--username and --password specified, using them for BMC credentials")
 			store = secrets.NewStaticStore(username, password)
 		} else {
 			// Alternatively, locate specific credentials (falling back to default) and override those
 			// with --username or --password if either are passed.
-			log.Debug().Str("uri", uri).Msgf("one or both of --username and --password NOT passed, attempting to obtain missing credentials from secret store at %s", secretsFile)
+			log.Debug().Str("id", uri).Msgf("one or both of --username and --password NOT passed, attempting to obtain missing credentials from secret store at %s", secretsFile)
 			if store, err = secrets.OpenStore(secretsFile); err != nil {
-				log.Error().Str("uri", uri).Err(err).Msg("failed to open local secrets store")
+				log.Error().Str("id", uri).Err(err).Msg("failed to open local secrets store")
 			}
 
 			// Either none of the flags were passed or only one of them were; get
 			// credentials from secrets store to fill in the gaps.
-			//
-			// Attempt to get URI-specific credentials.
-			var nodeCreds secrets.StaticStore
-			if uriCreds, err := store.GetSecretByID(uri); err != nil {
-				// Specific credentials for URI not found, fetch default.
-				log.Warn().Str("uri", uri).Msg("specific credentials not found, falling back to default")
-				defaultSecret, err := store.GetSecretByID(secrets.DEFAULT_KEY)
-				if err != nil {
-					// We've exhausted all options, the credentials will be blank unless
-					// overridden by a CLI flag.
-					log.Warn().Str("uri", uri).Err(err).Msg("no default credentials were set, they will be blank unless overridden by CLI flags")
-				} else {
-					// Default credentials found, use them.
-					var creds crawler.BMCUsernamePassword
-					if err = json.Unmarshal([]byte(defaultSecret), &creds); err != nil {
-						log.Warn().Str("uri", uri).Err(err).Msg("failed to unmarshal default secrets store credentials")
-					} else {
-						log.Info().Str("uri", uri).Msg("default credentials found, using")
-						nodeCreds.Username = creds.Username
-						nodeCreds.Password = creds.Password
-					}
-				}
-			} else {
-				// Specific URI credentials found, use them.
-				var creds crawler.BMCUsernamePassword
-				if err = json.Unmarshal([]byte(uriCreds), &creds); err != nil {
-					log.Warn().Str("uri", uri).Err(err).Msg("failed to unmarshal uri credentials")
-				} else {
-					nodeCreds.Username = creds.Username
-					nodeCreds.Password = creds.Password
-					log.Info().Str("uri", uri).Msg("specific credentials found, using")
-				}
+			bmcCreds, _ := bmc.GetBMCCredentials(store, uri)
+			nodeCreds := secrets.StaticStore{
+				Username: bmcCreds.Username,
+				Password: bmcCreds.Password,
 			}
 
 			// If either of the flags were passed, override the fetched
 			// credentials with them.
 			if username != "" {
-				log.Info().Str("uri", uri).Msg("--username was set, overriding username for this BMC")
+				log.Info().Str("id", uri).Msg("--username was set, overriding username for this BMC")
 				nodeCreds.Username = username
 			}
 			if password != "" {
-				log.Info().Str("uri", uri).Msg("--password was set, overriding password for this BMC")
+				log.Info().Str("id", uri).Msg("--password was set, overriding password for this BMC")
 				nodeCreds.Password = password
 			}
 

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -40,39 +40,67 @@ var CrawlCmd = &cobra.Command{
 			store secrets.SecretStore
 			err   error
 		)
-		// try and load credentials from local store first
-		store, err = secrets.OpenStore(secretsFile)
-		if err != nil {
-			log.Warn().Err(err).Msg("failed to open local store...falling back to provided arguments")
-			// try and use the `username` and `password` arguments instead
-			store = secrets.NewStaticStore(username, password)
-		}
 
-		// found the store so try to load the creds
-		_, err = store.GetSecretByID(uri)
-		if err != nil {
-			log.Warn().Err(err).Msgf("failed to get secrets for '%s'...", uri)
-			// if we have CLI flags set, then we want to override default stored creds
-			if username != "" && password != "" {
-				// finally, use the CLI arguments passed instead
-				log.Info().Msg("...using provided arguments for credentials")
-				store = secrets.NewStaticStore(username, password)
-			} else {
-				// try and get a default *stored* username/password
-				log.Info().Msg("...using default stored secrets for credentials")
-				secret, err := store.GetSecretByID(secrets.DEFAULT_KEY)
+		if username != "" && password != "" {
+			// First, try and load credentials from --username and --password if both are set.
+			log.Debug().Str("uri", uri).Msgf("--username and --password specified, using them for BMC credentials")
+			store = secrets.NewStaticStore(username, password)
+		} else {
+			// Alternatively, locate specific credentials (falling back to default) and override those
+			// with --username or --password if either are passed.
+			log.Debug().Str("uri", uri).Msgf("one or both of --username and --password NOT passed, attempting to obtain missing credentials from secret store at %s", secretsFile)
+			if store, err = secrets.OpenStore(secretsFile); err != nil {
+				log.Error().Str("uri", uri).Err(err).Msg("failed to open local secrets store")
+			}
+
+			// Either none of the flags were passed or only one of them were; get
+			// credentials from secrets store to fill in the gaps.
+			//
+			// Attempt to get URI-specific credentials.
+			var nodeCreds secrets.StaticStore
+			if uriCreds, err := store.GetSecretByID(uri); err != nil {
+				// Specific credentials for URI not found, fetch default.
+				log.Warn().Str("uri", uri).Msg("specific credentials not found, falling back to default")
+				defaultSecret, err := store.GetSecretByID(secrets.DEFAULT_KEY)
 				if err != nil {
-					// no default found, so use CLI arguments
-					log.Warn().Err(err).Msg("no default credentials found")
+					// We've exhausted all options, the credentials will be blank unless
+					// overridden by a CLI flag.
+					log.Warn().Str("uri", uri).Err(err).Msg("no default credentials were set, they will be blank unless overridden by CLI flags")
 				} else {
-					// found default values in local store so use them
+					// Default credentials found, use them.
 					var creds crawler.BMCUsernamePassword
-					err = json.Unmarshal([]byte(secret), &creds)
-					if err != nil {
-						log.Warn().Err(err).Msg("failed to unmarshal default store credentials")
+					if err = json.Unmarshal([]byte(defaultSecret), &creds); err != nil {
+						log.Warn().Str("uri", uri).Err(err).Msg("failed to unmarshal default secrets store credentials")
+					} else {
+						log.Info().Str("uri", uri).Msg("default credentials found, using")
+						nodeCreds.Username = creds.Username
+						nodeCreds.Password = creds.Password
 					}
 				}
+			} else {
+				// Specific URI credentials found, use them.
+				var creds crawler.BMCUsernamePassword
+				if err = json.Unmarshal([]byte(uriCreds), &creds); err != nil {
+					log.Warn().Str("uri", uri).Err(err).Msg("failed to unmarshal uri credentials")
+				} else {
+					nodeCreds.Username = creds.Username
+					nodeCreds.Password = creds.Password
+					log.Info().Str("uri", uri).Msg("specific credentials found, using")
+				}
 			}
+
+			// If either of the flags were passed, override the fetched
+			// credentials with them.
+			if username != "" {
+				log.Info().Str("uri", uri).Msg("--username was set, overriding username for this BMC")
+				nodeCreds.Username = username
+			}
+			if password != "" {
+				log.Info().Str("uri", uri).Msg("--password was set, overriding password for this BMC")
+				nodeCreds.Password = password
+			}
+
+			store = &nodeCreds
 		}
 
 		systems, err := crawler.CrawlBMCForSystems(crawler.CrawlerConfig{

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -43,7 +43,7 @@ var CrawlCmd = &cobra.Command{
 		// try and load credentials from local store first
 		store, err = secrets.OpenStore(secretsFile)
 		if err != nil {
-			log.Warn().Err(err).Msg("failed to open local store...falling back to default provided arguments")
+			log.Warn().Err(err).Msg("failed to open local store...falling back to provided arguments")
 			// try and use the `username` and `password` arguments instead
 			store = secrets.NewStaticStore(username, password)
 		}
@@ -51,12 +51,15 @@ var CrawlCmd = &cobra.Command{
 		// found the store so try to load the creds
 		_, err = store.GetSecretByID(uri)
 		if err != nil {
+			log.Warn().Err(err).Msgf("failed to get secrets for '%s'...", uri)
 			// if we have CLI flags set, then we want to override default stored creds
 			if username != "" && password != "" {
 				// finally, use the CLI arguments passed instead
+				log.Info().Msg("...using provided arguments for credentials")
 				store = secrets.NewStaticStore(username, password)
 			} else {
 				// try and get a default *stored* username/password
+				log.Info().Msg("...using default stored secrets for credentials")
 				secret, err := store.GetSecretByID(secrets.DEFAULT_KEY)
 				if err != nil {
 					// no default found, so use CLI arguments

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -17,13 +17,11 @@ import (
 // specfic inventory detail. This command only expects host names and does
 // not require a scan to be performed beforehand.
 var CrawlCmd = &cobra.Command{
-	Use:   "crawl [uri]",
+	Use: "crawl [uri]",
+	Example: `  magellan crawl https://bmc.example.com
+  magellan crawl https://bmc.example.com -i -u username -p password`,
 	Short: "Crawl a single BMC for inventory information",
-	Long: "Crawl a single BMC for inventory information with URI. This command does NOT scan subnets nor store scan information\n" +
-		"in cache after completion. To do so, use the 'collect' command instead\n\n" +
-		"Examples:\n" +
-		"  magellan crawl https://bmc.example.com\n" +
-		"  magellan crawl https://bmc.example.com -i -u username -p password",
+	Long:  "Crawl a single BMC for inventory information with URI.\n\n NOTE: This command does not scan subnets, store scan information in cache, nor make a request to a specified host. It is used only to retrieve inventory data directly. Otherwise, use 'scan' and 'collect' instead.",
 	Args: func(cmd *cobra.Command, args []string) error {
 		// Validate that the only argument is a valid URI
 		var err error
@@ -82,8 +80,6 @@ func init() {
 	CrawlCmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "Ignore SSL errors")
 	CrawlCmd.Flags().StringVarP(&secretsFile, "file", "f", "nodes.json", "set the secrets file with BMC credentials")
 
-	checkBindFlagError(viper.BindPFlag("crawl.username", CrawlCmd.Flags().Lookup("username")))
-	checkBindFlagError(viper.BindPFlag("crawl.password", CrawlCmd.Flags().Lookup("password")))
 	checkBindFlagError(viper.BindPFlag("crawl.insecure", CrawlCmd.Flags().Lookup("insecure")))
 
 	rootCmd.AddCommand(CrawlCmd)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -20,14 +20,15 @@ var (
 // and stored in a cache database from a scan. The data that's stored
 // is what is consumed by the `collect` command with the --cache flag.
 var ListCmd = &cobra.Command{
-	Use:   "list",
+	Use: "list",
+	Example: `  magellan list
+  magellan list --cache ./assets.db
+  magellan list --cache-info
+	`,
 	Args:  cobra.ExactArgs(0),
 	Short: "List information stored in cache from a scan",
 	Long: "Prints all of the host and associated data found from performing a scan.\n" +
-		"See the 'scan' command on how to perform a scan.\n\n" +
-		"Examples:\n" +
-		"  magellan list\n" +
-		"  magellan list --cache ./assets.db",
+		"See the 'scan' command on how to perform a scan.",
 	Run: func(cmd *cobra.Command, args []string) {
 		// check if we just want to show cache-related info and exit
 		if showCache {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "magellan",
 	Short: "Redfish-based BMC discovery tool",
-	Long:  "",
+	Long:  "Redfish-based BMC discovery tool with dynamic discovery features.",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			err := cmd.Help()
@@ -75,8 +75,8 @@ func Execute() {
 func init() {
 	currentUser, _ = user.Current()
 	cobra.OnInitialize(InitializeConfig)
-	rootCmd.PersistentFlags().IntVar(&concurrency, "concurrency", -1, "Set the number of concurrent processes")
-	rootCmd.PersistentFlags().IntVar(&timeout, "timeout", 5, "Set the timeout for requests")
+	rootCmd.PersistentFlags().IntVarP(&concurrency, "concurrency", "j", -1, "Set the number of concurrent processes")
+	rootCmd.PersistentFlags().IntVarP(&timeout, "timeout", "t", 5, "Set the timeout for requests")
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "Set the config file path")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Set to enable/disable verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Set to enable/disable debug messages")
@@ -94,7 +94,7 @@ func init() {
 
 func checkBindFlagError(err error) {
 	if err != nil {
-		log.Error().Err(err).Msg("failed to bind flag")
+		log.Error().Err(err).Msg("failed to bind cobra/viper flag")
 	}
 }
 

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -33,7 +33,28 @@ var (
 // See the `ScanForAssets()` function in 'internal/scan.go' for details
 // related to the implementation.
 var ScanCmd = &cobra.Command{
-	Use:   "scan urls...",
+	Use: "scan urls...",
+	Example: `
+  // assumes host https://10.0.0.101:443
+  magellan scan 10.0.0.101
+
+  // assumes subnet using HTTPS and port 443 except for specified host
+  magellan scan http://10.0.0.101:80 https://user:password@10.0.0.102:443 http://172.16.0.105:8080 --subnet 172.16.0.0/24
+
+  // assumes hosts http://10.0.0.101:8080 and http://10.0.0.102:8080
+  magellan scan 10.0.0.101 10.0.0.102 https://172.16.0.10:443 --port 8080 --protocol tcp
+
+  // assumes subnet using default unspecified subnet-masks
+  magellan scan --subnet 10.0.0.0
+
+  // assumes subnet using HTTPS and port 443 with specified CIDR
+  magellan scan --subnet 10.0.0.0/16
+
+  // assumes subnet using HTTP and port 5000 similar to 192.168.0.0/16
+  magellan scan --subnet 192.168.0.0 --protocol tcp --scheme https --port 5000 --subnet-mask 255.255.0.0
+
+  // assumes subnet without CIDR has a subnet-mask of 255.255.0.0
+  magellan scan --subnet 10.0.0.0/24 --subnet 172.16.0.0 --subnet-mask 255.255.0.0 --cache ./assets.db`,
 	Short: "Scan to discover BMC nodes on a network",
 	Long: "Perform a net scan by attempting to connect to each host and port specified and getting a response.\n" +
 		"Each host is passed *with a full URL* including the protocol and port. Additional subnets can be added\n" +
@@ -46,22 +67,7 @@ var ScanCmd = &cobra.Command{
 		"'--protocol' flag.\n\n" +
 		"If the '--disable-probe` flag is used, the tool will not send another request to probe for available.\n" +
 		"Redfish services. This is not recommended, since the extra request makes the scan a bit more reliable\n" +
-		"for determining which hosts to collect inventory data.\n\n" +
-		"Examples:\n" +
-		// assumes host https://10.0.0.101:443
-		"  magellan scan 10.0.0.101\n" +
-		// assumes subnet using HTTPS and port 443 except for specified host
-		"  magellan scan http://10.0.0.101:80 https://user:password@10.0.0.102:443 http://172.16.0.105:8080 --subnet 172.16.0.0/24\n" +
-		// assumes hosts http://10.0.0.101:8080 and http://10.0.0.102:8080
-		"  magellan scan 10.0.0.101 10.0.0.102 https://172.16.0.10:443 --port 8080 --protocol tcp\n" +
-		// assumes subnet using default unspecified subnet-masks
-		"  magellan scan --subnet 10.0.0.0\n" +
-		// assumes subnet using HTTPS and port 443 with specified CIDR
-		"  magellan scan --subnet 10.0.0.0/16\n" +
-		// assumes subnet using HTTP and port 5000 similar to 192.168.0.0/16
-		"  magellan scan --subnet 192.168.0.0 --protocol tcp --scheme https --port 5000 --subnet-mask 255.255.0.0\n" +
-		// assumes subnet without CIDR has a subnet-mask of 255.255.0.0
-		"  magellan scan --subnet 10.0.0.0/24 --subnet 172.16.0.0 --subnet-mask 255.255.0.0 --cache ./assets.db\n",
+		"for determining which hosts to collect inventory data.\n\n",
 	Run: func(cmd *cobra.Command, args []string) {
 		// add default ports for hosts if none are specified with flag
 		if len(ports) == 0 {

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -64,7 +64,7 @@ var secretsStoreCmd = &cobra.Command{
 	Short: "Stores the given string value under secretID.",
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
-			secretID       string = args[0]
+			secretID       = args[0]
 			secretValue    string
 			store          secrets.SecretStore
 			inputFileBytes []byte
@@ -167,7 +167,7 @@ var secretsStoreCmd = &cobra.Command{
 
 func isValidCredsJSON(val string) bool {
 	var (
-		valid bool = !json.Valid([]byte(val))
+		valid = !json.Valid([]byte(val))
 		creds map[string]string
 		err   error
 	)

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -20,17 +20,21 @@ var (
 )
 
 var secretsCmd = &cobra.Command{
-	Use:   "secrets",
+	Use: "secrets",
+	Example: `
+  // generate new key and set environment variable
+  export MASTER_KEY=$(magellan secrets generatekey)
+
+  // store specific BMC node creds for collect and crawl in default secrets store (--file/-f flag not set)
+  magellan secrets store $bmc_host $bmc_creds
+
+  // retrieve creds from secrets store
+  magellan secrets retrieve $bmc_host -f nodes.json
+
+  // list creds from specific secrets
+  magellan secrets list -f nodes.json`,
 	Short: "Manage credentials for BMC nodes",
-	Long: "Manage credentials for BMC nodes to for querying information through redfish. This requires generating a key and setting the 'MASTER_KEY' environment variable for the secrets store.\n" +
-		"Examples:\n\n" +
-		"    export MASTER_KEY=$(magellan secrets generatekey)\n" +
-		// store specific BMC node creds for `collect` and `crawl` in default secrets store (`--file/-f`` flag not set)
-		"    magellan secrets store $bmc_host $bmc_creds" +
-		// retrieve creds from secrets store
-		"    magellan secrets retrieve $bmc_host -f nodes.json" +
-		// list creds from specific secrets
-		"    magellan secrets list -f nodes.json",
+	Long:  "Manage credentials for BMC nodes to for querying information through redfish. This requires generating a key and setting the 'MASTER_KEY' environment variable for the secrets store.",
 	Run: func(cmd *cobra.Command, args []string) {
 		// show command help and exit
 		if len(args) < 1 {
@@ -60,7 +64,7 @@ var secretsStoreCmd = &cobra.Command{
 	Short: "Stores the given string value under secretID.",
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
-			secretID       = args[0]
+			secretID       string = args[0]
 			secretValue    string
 			store          secrets.SecretStore
 			inputFileBytes []byte
@@ -163,7 +167,7 @@ var secretsStoreCmd = &cobra.Command{
 
 func isValidCredsJSON(val string) bool {
 	var (
-		valid = !json.Valid([]byte(val))
+		valid bool = !json.Valid([]byte(val))
 		creds map[string]string
 		err   error
 	)
@@ -219,8 +223,8 @@ var secretsListCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		for key := range secrets {
-			fmt.Printf("%s\n", key)
+		for key, value := range secrets {
+			fmt.Printf("%s: %s\n", key, value)
 		}
 	},
 }

--- a/internal/util/bmc.go
+++ b/internal/util/bmc.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"github.com/OpenCHAMI/magellan/pkg/bmc"
+	"github.com/OpenCHAMI/magellan/pkg/secrets"
+	"github.com/rs/zerolog/log"
+)
+
+func GetBMCCredentials(store secrets.SecretStore, id string) bmc.BMCCredentials {
+	var (
+		creds bmc.BMCCredentials
+		err   error
+	)
+
+	if id == "" {
+		log.Error().Msg("failed to get BMC credentials: id was empty")
+		return creds
+	}
+
+	if id == secrets.DEFAULT_KEY {
+		log.Info().Msg("fetching default credentials")
+		if creds, err = bmc.GetBMCCredentialsDefault(store); err != nil {
+			log.Warn().Err(err).Msg("failed to get default credentials")
+		} else {
+			log.Info().Msg("default credentials found, using")
+		}
+		return creds
+	}
+
+	if creds, err = bmc.GetBMCCredentials(store, id); err != nil {
+		// Specific credentials for URI not found, fetch default.
+		log.Warn().Str("id", id).Msg("specific credentials not found, falling back to default")
+		if defaultSecret, err := bmc.GetBMCCredentialsDefault(store); err != nil {
+			// We've exhausted all options, the credentials will be blank unless
+			// overridden by a CLI flag.
+			log.Warn().Str("id", id).Err(err).Msg("no default credentials were set, they will be blank unless overridden by CLI flags")
+		} else {
+			// Default credentials found, use them.
+			log.Info().Str("id", id).Msg("default credentials found, using")
+			creds = defaultSecret
+		}
+	} else {
+		log.Info().Str("id", id).Msg("specific credentials found, using")
+	}
+
+	return creds
+}

--- a/pkg/bmc/bmc.go
+++ b/pkg/bmc/bmc.go
@@ -1,0 +1,65 @@
+package bmc
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/OpenCHAMI/magellan/pkg/secrets"
+)
+
+type BMCCredentials struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func GetBMCCredentialsDefault(store secrets.SecretStore) (BMCCredentials, error) {
+	var creds BMCCredentials
+	if strCreds, err := store.GetSecretByID(secrets.DEFAULT_KEY); err != nil {
+		return creds, fmt.Errorf("get default BMC credentials from secret store: %w", err)
+	} else {
+		// Default URI credentials found, use them.
+		if err = json.Unmarshal([]byte(strCreds), &creds); err != nil {
+			return creds, fmt.Errorf("get default BMC credentials from secret store: failed to unmarshal: %w", err)
+		}
+		return creds, nil
+	}
+}
+
+func GetBMCCredentials(store secrets.SecretStore, id string) (BMCCredentials, error) {
+	var creds BMCCredentials
+	if strCreds, err := store.GetSecretByID(id); err != nil {
+		return creds, fmt.Errorf("get BMC credentials from secret store: %w", err)
+	} else {
+		// Specific URI credentials found, use them.
+		if err = json.Unmarshal([]byte(strCreds), &creds); err != nil {
+			return creds, fmt.Errorf("get BMC credentials from secret store: failed to unmarshal: %w", err)
+		}
+	}
+
+	return creds, nil
+}
+
+func GetBMCCredentialsOrDefault(store secrets.SecretStore, id string) BMCCredentials {
+	var (
+		creds BMCCredentials
+		err   error
+	)
+
+	if id == "" {
+		return creds
+	}
+
+	if id == secrets.DEFAULT_KEY {
+		creds, _ = GetBMCCredentialsDefault(store)
+		return creds
+	}
+
+	if creds, err = GetBMCCredentials(store, id); err != nil {
+		if defaultSecret, err := GetBMCCredentialsDefault(store); err == nil {
+			// Default credentials found, use them.
+			creds = defaultSecret
+		}
+	}
+
+	return creds
+}

--- a/pkg/collect.go
+++ b/pkg/collect.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/OpenCHAMI/magellan/pkg/bmc"
 	"github.com/OpenCHAMI/magellan/pkg/client"
 	"github.com/OpenCHAMI/magellan/pkg/crawler"
 	"github.com/OpenCHAMI/magellan/pkg/secrets"
@@ -31,17 +32,15 @@ import (
 // CollectParams is a collection of common parameters passed to the CLI
 // for the 'collect' subcommand.
 type CollectParams struct {
-	URI         string // set by the 'host' flag
-	Username    string // set the BMC username with the 'username' flag
-	Password    string // set the BMC password with the 'password' flag
-	Concurrency int    // set the of concurrent jobs with the 'concurrency' flag
-	Timeout     int    // set the timeout with the 'timeout' flag
-	CaCertPath  string // set the cert path with the 'cacert' flag
-	Verbose     bool   // set whether to include verbose output with 'verbose' flag
-	OutputPath  string // set the path to save output with 'output' flag
-	ForceUpdate bool   // set whether to force updating SMD with 'force-update' flag
-	AccessToken string // set the access token to include in request with 'access-token' flag
-	SecretsFile string // set the path to secrets file
+	URI         string              // set by the 'host' flag
+	Concurrency int                 // set the of concurrent jobs with the 'concurrency' flag
+	Timeout     int                 // set the timeout with the 'timeout' flag
+	CaCertPath  string              // set the cert path with the 'cacert' flag
+	Verbose     bool                // set whether to include verbose output with 'verbose' flag
+	OutputPath  string              // set the path to save output with 'output' flag
+	ForceUpdate bool                // set whether to force updating SMD with 'force-update' flag
+	AccessToken string              // set the access token to include in request with 'access-token' flag
+	SecretStore secrets.SecretStore // set BMC credentials
 }
 
 // This is the main function used to collect information from the BMC nodes via Redfish.
@@ -50,7 +49,7 @@ type CollectParams struct {
 //
 // Requests can be made to several of the nodes using a goroutine by setting the q.Concurrency
 // property value between 1 and 10000.
-func CollectInventory(assets *[]RemoteAsset, params *CollectParams, localStore secrets.SecretStore) ([]map[string]any, error) {
+func CollectInventory(assets *[]RemoteAsset, params *CollectParams) ([]map[string]any, error) {
 	// check for available remote assets found from scan
 	if assets == nil {
 		return nil, fmt.Errorf("no assets found")
@@ -120,46 +119,36 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams, localStore s
 
 				// crawl BMC node to fetch inventory data via Redfish
 				var (
-					fallbackStore = secrets.NewStaticStore(params.Username, params.Password)
-					systems       []crawler.InventoryDetail
-					managers      []crawler.Manager
-					config        = crawler.CrawlerConfig{
+					systems  []crawler.InventoryDetail
+					managers []crawler.Manager
+					config   = crawler.CrawlerConfig{
 						URI:             uri,
-						CredentialStore: localStore,
+						CredentialStore: params.SecretStore,
 						Insecure:        true,
 						UseDefault:      true,
 					}
 					err error
 				)
 
-				// determine if local store exists and has credentials for
-				// the provided secretID...
-				// if it does not, use the fallback static store instead with
-				// the username and password provided as arguments
-				if localStore != nil {
-					_, err := localStore.GetSecretByID(uri)
-					if err != nil {
-						log.Warn().Err(err).Msgf("could not retrieve secrets for '%s'...falling back to credentials provided with flags -u/-p for user '%s'", uri, params.Username)
-						if params.Username != "" && params.Password != "" {
-							config.CredentialStore = fallbackStore
-						} else if !config.UseDefault {
-							log.Warn().Msgf("no fallback credentials provided for '%s'", params.Username)
-							continue
-						}
-					}
-				} else {
-					log.Warn().Msgf("invalid store for %s...falling back to default provided credentials for user '%s'", uri, params.Username)
-					config.CredentialStore = fallbackStore
-				}
-
 				// crawl for node and BMC information
 				systems, err = crawler.CrawlBMCForSystems(config)
 				if err != nil {
-					log.Error().Err(err).Msg("failed to crawl BMC for systems")
+					log.Error().Err(err).Str("uri", uri).Msg("failed to crawl BMC for systems")
 				}
 				managers, err = crawler.CrawlBMCForManagers(config)
 				if err != nil {
-					log.Error().Err(err).Msg("failed to crawl BMC for managers")
+					log.Error().Err(err).Str("uri", uri).Msg("failed to crawl BMC for managers")
+				}
+
+				// we didn't find anything so do not proceed
+				if len(systems) == 0 && len(managers) == 0 {
+					continue
+				}
+
+				// get BMC username to send
+				bmcCreds := bmc.GetBMCCredentialsOrDefault(params.SecretStore, config.URI)
+				if bmcCreds == (bmc.BMCCredentials{}) {
+					log.Warn().Str("id", config.URI).Msg("username will be blank")
 				}
 
 				// data to be sent to smd
@@ -168,7 +157,7 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams, localStore s
 					"Type":               "",
 					"Name":               "",
 					"FQDN":               sr.Host,
-					"User":               params.Username,
+					"User":               bmcCreds.Username,
 					"MACRequired":        true,
 					"RediscoverOnUpdate": false,
 					"Systems":            systems,

--- a/pkg/collect.go
+++ b/pkg/collect.go
@@ -127,6 +127,7 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams, localStore s
 						URI:             uri,
 						CredentialStore: localStore,
 						Insecure:        true,
+						UseDefault:      true,
 					}
 					err error
 				)
@@ -138,8 +139,13 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams, localStore s
 				if localStore != nil {
 					_, err := localStore.GetSecretByID(uri)
 					if err != nil {
-						log.Warn().Err(err).Msgf("could not retrieve secrets for %s...falling back to default provided credentials for user '%s'", uri, params.Username)
-						config.CredentialStore = fallbackStore
+						log.Warn().Err(err).Msgf("could not retrieve secrets for '%s'...falling back to credentials provided with flags -u/-p for user '%s'", uri, params.Username)
+						if params.Username != "" && params.Password != "" {
+							config.CredentialStore = fallbackStore
+						} else if !config.UseDefault {
+							log.Warn().Msgf("no fallback credentials provided for '%s'", params.Username)
+							continue
+						}
 					}
 				} else {
 					log.Warn().Msgf("invalid store for %s...falling back to default provided credentials for user '%s'", uri, params.Username)

--- a/pkg/secrets/main.go
+++ b/pkg/secrets/main.go
@@ -1,5 +1,7 @@
 package secrets
 
+const DEFAULT_KEY = "default"
+
 type SecretStore interface {
 	GetSecretByID(secretID string) (string, error)
 	StoreSecretByID(secretID, secret string) error

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -10,9 +10,7 @@ import (
 
 type UpdateParams struct {
 	CollectParams
-	FirmwarePath     string
-	FirmwareVersion  string
-	Component        string
+	FirmwareURI      string
 	TransferProtocol string
 	Insecure         bool
 }
@@ -51,7 +49,7 @@ func UpdateFirmwareRemote(q *UpdateParams) error {
 
 	// Build the update request payload
 	req := redfish.SimpleUpdateParameters{
-		ImageURI:         q.FirmwarePath,
+		ImageURI:         q.FirmwareURI,
 		TransferProtocol: redfish.TransferProtocolType(q.TransferProtocol),
 	}
 

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/OpenCHAMI/magellan/pkg/bmc"
 	"github.com/stmcginnis/gofish"
 	"github.com/stmcginnis/gofish/redfish"
 )
@@ -34,8 +35,14 @@ func UpdateFirmwareRemote(q *UpdateParams) error {
 		return fmt.Errorf("failed to parse URI: %w", err)
 	}
 
+	// Get BMC credentials from secret store in update parameters
+	bmcCreds, err := bmc.GetBMCCredentials(q.SecretStore, q.URI)
+	if err != nil {
+		return fmt.Errorf("failed to get BMC credentials: %w", err)
+	}
+
 	// Connect to the Redfish service using gofish
-	client, err := gofish.Connect(gofish.ClientConfig{Endpoint: uri.String(), Username: q.Username, Password: q.Password, Insecure: q.Insecure})
+	client, err := gofish.Connect(gofish.ClientConfig{Endpoint: uri.String(), Username: bmcCreds.Username, Password: bmcCreds.Password, Insecure: q.Insecure})
 	if err != nil {
 		return fmt.Errorf("failed to connect to Redfish service: %w", err)
 	}
@@ -70,8 +77,14 @@ func GetUpdateStatus(q *UpdateParams) error {
 		return fmt.Errorf("failed to parse URI: %w", err)
 	}
 
+	// Get BMC credentials from secret store in update parameters
+	bmcCreds, err := bmc.GetBMCCredentials(q.SecretStore, q.URI)
+	if err != nil {
+		return fmt.Errorf("failed to get BMC credentials: %w", err)
+	}
+
 	// Connect to the Redfish service using gofish
-	client, err := gofish.Connect(gofish.ClientConfig{Endpoint: uri.String(), Username: q.Username, Password: q.Password, Insecure: q.Insecure})
+	client, err := gofish.Connect(gofish.ClientConfig{Endpoint: uri.String(), Username: bmcCreds.Username, Password: bmcCreds.Password, Insecure: q.Insecure})
 	if err != nil {
 		return fmt.Errorf("failed to connect to Redfish service: %w", err)
 	}


### PR DESCRIPTION
This PR addresses #85 by adding a credentials lookup for a "default" key in the local secrets store. This allows adding default credentials without having to set the `--username` and `--password` flags as a fallback if there is no credential for a specific host. This PR also updates the `secrets` documentation with the relevant information.

This features works by simply adding a `default` key to the store.

```bash
export MASTER_KEY=(magellan secrets generatekey)
magellan secrets default $username:$password

magellan secrets list
# default: ...
```

From there, perform a `crawl` or `collect` like before but without specifying the `--username/--password` flags. Here is what the work flow would look like for both cases:

1. Basic setup and starting the emulator

```bash
cd $magellan
git checkout default-secrets
make emulator
```

2.a. Add secrets then crawl emulator host if known beforehand

```bash
magellan secrets default root:root_password
magellan crawl -i https://172.18.0.2:5000
```

2.b. Dynamically scan, list, add secrets, then collect with emulator if hosts are not known

```bash
magellan scan --subnet 172.19.0.0/24 --port 5000
magellan list
magellan secrets default root:root_password
magellan collect
```

The order of precedence for the lookup is as follows:

1. Use the local store credentials for specific host if it exists
2. Lookup default credential if "default" `secretID` is stored
3. Use credentials set by `--username/--password` flags