### PR TITLE
Split the `collect` Command For Customization

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -74,6 +74,7 @@ var CollectCmd = &cobra.Command{
 			SecretsFile: secretsFile,
 			Username:    username,
 			Password:    password,
+			Format:      format,
 		}
 
 		// show all of the 'collect' parameters being set from CLI if verbose
@@ -122,15 +123,17 @@ var CollectCmd = &cobra.Command{
 
 func init() {
 	currentUser, _ = user.Current()
-	CollectCmd.PersistentFlags().StringVar(&host, "host", "", "Set the URI to the SMD root endpoint")
-	CollectCmd.PersistentFlags().StringVarP(&username, "username", "u", "", "Set the master BMC username")
-	CollectCmd.PersistentFlags().StringVarP(&password, "password", "p", "", "Set the master BMC password")
-	CollectCmd.PersistentFlags().StringVar(&secretsFile, "secrets-file", "", "Set path to the node secrets file")
-	CollectCmd.PersistentFlags().StringVar(&scheme, "scheme", "https", "Set the default scheme used to query when not included in URI")
-	CollectCmd.PersistentFlags().StringVar(&protocol, "protocol", "tcp", "Set the protocol used to query")
-	CollectCmd.PersistentFlags().StringVarP(&outputPath, "output", "o", fmt.Sprintf("/tmp/%smagellan/inventory/", currentUser.Username+"/"), "Set the path to store collection data")
-	CollectCmd.PersistentFlags().BoolVar(&forceUpdate, "force-update", false, "Set flag to force update data sent to SMD")
-	CollectCmd.PersistentFlags().StringVar(&cacertPath, "cacert", "", "Set the path to CA cert file. (defaults to system CAs when blank)")
+	CollectCmd.Flags().StringVar(&host, "host", "", "Set the URI to the SMD root endpoint")
+	CollectCmd.Flags().StringVarP(&username, "username", "u", "", "Set the master BMC username")
+	CollectCmd.Flags().StringVarP(&password, "password", "p", "", "Set the master BMC password")
+	CollectCmd.Flags().StringVar(&secretsFile, "secrets-file", "", "Set path to the node secrets file")
+	CollectCmd.Flags().StringVar(&scheme, "scheme", "https", "Set the default scheme used to query when not included in URI")
+	CollectCmd.Flags().StringVar(&protocol, "protocol", "tcp", "Set the protocol used to query")
+	CollectCmd.Flags().StringVarP(&outputPath, "output", "o", fmt.Sprintf("/tmp/%smagellan/inventory/", currentUser.Username+"/"), "Set the path to store collection data")
+	CollectCmd.Flags().BoolVar(&forceUpdate, "force-update", false, "Set flag to force update data sent to SMD")
+	CollectCmd.Flags().StringVar(&cacertPath, "cacert", "", "Set the path to CA cert file. (defaults to system CAs when blank)")
+	CollectCmd.Flags().StringVarP(&format, "format", "F", "hive", "Set the output format (json|yaml)")
+	CollectCmd.Flags().BoolVar(&useHive, "use-hive", true, "Set the output format")
 
 	// set flags to only be used together
 	CollectCmd.MarkFlagsRequiredTogether("username", "password")
@@ -143,6 +146,7 @@ func init() {
 	checkBindFlagError(viper.BindPFlag("collect.force-update", CollectCmd.Flags().Lookup("force-update")))
 	checkBindFlagError(viper.BindPFlag("collect.cacert", CollectCmd.Flags().Lookup("cacert")))
 	checkBindFlagError(viper.BindPFlags(CollectCmd.Flags()))
+	checkBindFlagError(viper.BindPFlag("collect.use-hive", CollectCmd.Flags().Lookup("use-hive")))
 
 	rootCmd.AddCommand(CollectCmd)
 }

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -161,8 +161,8 @@ func init() {
 	checkBindFlagError(viper.BindPFlag("collect.output", CollectCmd.Flags().Lookup("output")))
 	checkBindFlagError(viper.BindPFlag("collect.force-update", CollectCmd.Flags().Lookup("force-update")))
 	checkBindFlagError(viper.BindPFlag("collect.cacert", CollectCmd.Flags().Lookup("cacert")))
-	checkBindFlagError(viper.BindPFlags(CollectCmd.Flags()))
 	checkBindFlagError(viper.BindPFlag("collect.use-hive", CollectCmd.Flags().Lookup("use-hive")))
+	checkBindFlagError(viper.BindPFlags(CollectCmd.Flags()))
 
 	rootCmd.AddCommand(CollectCmd)
 }

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os/user"
 
 	"github.com/OpenCHAMI/magellan/internal/cache/sqlite"
 	urlx "github.com/OpenCHAMI/magellan/internal/url"
+	"github.com/OpenCHAMI/magellan/internal/util"
 	magellan "github.com/OpenCHAMI/magellan/pkg"
 	"github.com/OpenCHAMI/magellan/pkg/auth"
 	"github.com/OpenCHAMI/magellan/pkg/bmc"
@@ -141,14 +141,13 @@ var CollectCmd = &cobra.Command{
 }
 
 func init() {
-	currentUser, _ = user.Current()
 	CollectCmd.Flags().StringVar(&host, "host", "", "Set the URI to the SMD root endpoint")
 	CollectCmd.Flags().StringVarP(&username, "username", "u", "", "Set the master BMC username")
 	CollectCmd.Flags().StringVarP(&password, "password", "p", "", "Set the master BMC password")
 	CollectCmd.Flags().StringVar(&secretsFile, "secrets-file", "", "Set path to the node secrets file")
 	CollectCmd.Flags().StringVar(&scheme, "scheme", "https", "Set the default scheme used to query when not included in URI")
 	CollectCmd.Flags().StringVar(&protocol, "protocol", "tcp", "Set the protocol used to query")
-	CollectCmd.Flags().StringVarP(&outputPath, "output", "o", fmt.Sprintf("/tmp/%smagellan/inventory/", currentUser.Username+"/"), "Set the path to store collection data")
+	CollectCmd.Flags().StringVarP(&outputPath, "output", "o", fmt.Sprintf("/tmp/%smagellan/inventory/", util.GetCurrentUsername()+"/"), "Set the path to store collection data")
 	CollectCmd.Flags().BoolVar(&forceUpdate, "force-update", false, "Set flag to force update data sent to SMD")
 	CollectCmd.Flags().StringVar(&cacertPath, "cacert", "", "Set the path to CA cert file. (defaults to system CAs when blank)")
 	CollectCmd.Flags().StringVarP(&format, "format", "F", "hive", "Set the output format (json|yaml)")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,17 +3,20 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/OpenCHAMI/magellan/internal/cache/sqlite"
 	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
 
 	"github.com/spf13/cobra"
 )
 
 var (
-	showCache bool
+	showCache        bool
+	listOutputFormat string
 )
 
 // The `list` command provides an easy way to show what was found
@@ -41,23 +44,32 @@ var ListCmd = &cobra.Command{
 		if err != nil {
 			log.Error().Err(err).Msg("failed to get scanned assets")
 		}
-		format = strings.ToLower(format)
-		if format == "json" {
+		switch strings.ToLower(listOutputFormat) {
+		case FORMAT_JSON:
 			b, err := json.Marshal(scannedResults)
 			if err != nil {
-				log.Error().Err(err).Msgf("failed to unmarshal scanned results")
+				log.Error().Err(err).Msgf("failed to unmarshal cached data to JSON")
 			}
 			fmt.Printf("%s\n", string(b))
-		} else {
+		case FORMAT_YAML:
+			b, err := yaml.Marshal(scannedResults)
+			if err != nil {
+				log.Error().Err(err).Msgf("failed to unmarshal cached data to YAML")
+			}
+			fmt.Printf("%s\n", string(b))
+		case FORMAT_TABLE:
 			for _, r := range scannedResults {
 				fmt.Printf("%s:%d (%s) @%s\n", r.Host, r.Port, r.Protocol, r.Timestamp.Format(time.UnixDate))
 			}
+		default:
+			log.Error().Msg("unknown format")
+			os.Exit(1)
 		}
 	},
 }
 
 func init() {
-	ListCmd.Flags().StringVar(&format, "format", "", "Set the output format (json|default)")
+	ListCmd.Flags().StringVarP(&listOutputFormat, "format", "F", FORMAT_TABLE, "Set the output format (json|yaml|table)")
 	ListCmd.Flags().BoolVar(&showCache, "cache-info", false, "Show cache information and exit")
 	rootCmd.AddCommand(ListCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,14 +27,14 @@ import (
 )
 
 const (
-	FORMAT_JSON = "json"
-	FORMAT_YAML = "yaml"
+	FORMAT_TABLE = "table"
+	FORMAT_JSON  = "json"
+	FORMAT_YAML  = "yaml"
 )
 
 // CLI arguments as variables to not fiddle with error-prone strings
 var (
 	accessToken string
-	format      string
 	timeout     int
 	concurrency int
 	ports       []int

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,11 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	FORMAT_JSON = "json"
+	FORMAT_YAML = "yaml"
+)
+
 var (
 	currentUser *user.User
 	accessToken string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/user"
 
 	magellan "github.com/OpenCHAMI/magellan/internal"
+	"github.com/OpenCHAMI/magellan/internal/util"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -31,8 +31,8 @@ const (
 	FORMAT_YAML = "yaml"
 )
 
+// CLI arguments as variables to not fiddle with error-prone strings
 var (
-	currentUser *user.User
 	accessToken string
 	format      string
 	timeout     int
@@ -79,7 +79,6 @@ func Execute() {
 }
 
 func init() {
-	currentUser, _ = user.Current()
 	cobra.OnInitialize(InitializeConfig)
 	rootCmd.PersistentFlags().IntVarP(&concurrency, "concurrency", "j", -1, "Set the number of concurrent processes")
 	rootCmd.PersistentFlags().IntVarP(&timeout, "timeout", "t", 5, "Set the timeout for requests")
@@ -87,7 +86,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Set to enable/disable verbose output")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Set to enable/disable debug messages")
 	rootCmd.PersistentFlags().StringVar(&accessToken, "access-token", "", "Set the access token")
-	rootCmd.PersistentFlags().StringVar(&cachePath, "cache", fmt.Sprintf("/tmp/%s/magellan/assets.db", currentUser.Username), "Set the scanning result cache path")
+	rootCmd.PersistentFlags().StringVar(&cachePath, "cache", fmt.Sprintf("/tmp/%s/magellan/assets.db", util.GetCurrentUsername()), "Set the scanning result cache path")
 
 	// bind viper config flags with cobra
 	checkBindFlagError(viper.BindPFlag("concurrency", rootCmd.PersistentFlags().Lookup("concurrency")))
@@ -123,13 +122,12 @@ func InitializeConfig() {
 // TODO: This function should probably be moved to 'internal/config.go'
 // instead of in this file.
 func SetDefaults() {
-	currentUser, _ = user.Current()
 	viper.SetDefault("threads", 1)
 	viper.SetDefault("timeout", 5)
 	viper.SetDefault("config", "")
 	viper.SetDefault("verbose", false)
 	viper.SetDefault("debug", false)
-	viper.SetDefault("cache", fmt.Sprintf("/tmp/%s/magellan/assets.db", currentUser.Username))
+	viper.SetDefault("cache", fmt.Sprintf("/tmp/%s/magellan/assets.db", util.GetCurrentUsername()))
 	viper.SetDefault("scan.hosts", []string{})
 	viper.SetDefault("scan.ports", []int{})
 	viper.SetDefault("scan.subnets", []string{})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ var (
 	debug       bool
 	forceUpdate bool
 	insecure    bool
+	useHive     bool
 )
 
 // The `root` command doesn't do anything on it's own except display
@@ -79,7 +80,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&timeout, "timeout", "t", 5, "Set the timeout for requests")
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "Set the config file path")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Set to enable/disable verbose output")
-	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Set to enable/disable debug messages")
+	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Set to enable/disable debug messages")
 	rootCmd.PersistentFlags().StringVar(&accessToken, "access-token", "", "Set the access token")
 	rootCmd.PersistentFlags().StringVar(&cachePath, "cache", fmt.Sprintf("/tmp/%s/magellan/assets.db", currentUser.Username), "Set the scanning result cache path")
 

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -79,18 +79,8 @@ var ScanCmd = &cobra.Command{
 
 		// format and combine flag and positional args
 		targetHosts = append(targetHosts, urlx.FormatHosts(args, ports, scheme, verbose)...)
-		targetHosts = append(targetHosts, urlx.FormatHosts(hosts, ports, scheme, verbose)...)
 
-		// add more hosts specified with `--subnet` flag
-		if debug {
-			log.Debug().Msg("adding hosts from subnets")
-		}
 		for _, subnet := range subnets {
-			// subnet string is empty so nothing to do here
-			if subnet == "" {
-				continue
-			}
-
 			// generate a slice of all hosts to scan from subnets
 			subnetHosts := magellan.GenerateHostsWithSubnet(subnet, &subnetMask, ports, scheme)
 			targetHosts = append(targetHosts, subnetHosts...)
@@ -180,8 +170,6 @@ var ScanCmd = &cobra.Command{
 }
 
 func init() {
-	// scanCmd.Flags().StringSliceVar(&hosts, "host", []string{}, "set additional hosts to scan")
-	ScanCmd.Flags().StringSliceVar(&hosts, "host", nil, "Add individual hosts to scan. (example: https://my.bmc.com:5000; same as using positional args)")
 	ScanCmd.Flags().IntSliceVar(&ports, "port", nil, "Adds additional ports to scan for each host with unspecified ports.")
 	ScanCmd.Flags().StringVar(&scheme, "scheme", "https", "Set the default scheme to use if not specified in host URI. (default is 'https')")
 	ScanCmd.Flags().StringVar(&protocol, "protocol", "tcp", "Set the default protocol to use in scan. (default is 'tcp')")

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -256,9 +256,9 @@ var secretsRemoveCmd = &cobra.Command{
 }
 
 func init() {
-	secretsCmd.Flags().StringVarP(&secretsFile, "file", "f", "nodes.json", "set the secrets file with BMC credentials")
-	secretsStoreCmd.Flags().StringVarP(&secretsStoreFormat, "format", "F", "basic", "set the input format for the secrets file (basic|json|base64)")
-	secretsStoreCmd.Flags().StringVarP(&secretsStoreInputFile, "input-file", "i", "", "set the file to read as input")
+	secretsCmd.Flags().StringVarP(&secretsFile, "file", "f", "secrets.json", "Set the secrets file with BMC credentials.")
+	secretsStoreCmd.Flags().StringVarP(&secretsStoreFormat, "format", "F", "basic", "Set the input format for the secrets file (basic|json|base64).")
+	secretsStoreCmd.Flags().StringVarP(&secretsStoreInputFile, "input-file", "i", "", "Set the file to read as input.")
 
 	secretsCmd.AddCommand(secretsGenerateKeyCmd)
 	secretsCmd.AddCommand(secretsStoreCmd)

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -3,18 +3,21 @@ package cmd
 import (
 	"crypto/x509"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
-	"strings"
 
 	urlx "github.com/OpenCHAMI/magellan/internal/url"
 	"github.com/OpenCHAMI/magellan/pkg/auth"
 	"github.com/OpenCHAMI/magellan/pkg/client"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
-var sendData []string
+var (
+	sendDataArgs []string
+)
 
 var sendCmd = &cobra.Command{
 	Use: "send [host]",
@@ -28,8 +31,36 @@ var sendCmd = &cobra.Command{
 		// concatenate all of the data from `-d` flag to send
 		var (
 			smdClient = &client.SmdClient{Client: &http.Client{}}
-			inputData = []byte(strings.Join(sendData, "\n"))
+			inputData []byte
 		)
+
+		// load data either from file or directly from args
+		for _, dataArg := range sendDataArgs {
+			// determine if we're reading from file
+			if len(dataArg) > 0 {
+				// load from file
+				if dataArg[0] == '@' {
+					var (
+						path     string = dataArg[1:]
+						contents []byte
+						err      error
+					)
+					contents, err = os.ReadFile(path)
+					if err != nil {
+						log.Error().Err(err).Str("path", path).Msg("failed to read file")
+						continue
+					}
+					inputData = append(inputData, []byte(contents)...)
+					fmt.Println("file:\n", string(contents))
+				} else {
+					// read data directly
+					inputData = append(inputData, []byte(dataArg)...)
+					fmt.Println("data:\n", string(dataArg))
+				}
+			} else {
+				continue
+			}
+		}
 
 		// try to load access token either from env var, file, or config if var not set
 		if accessToken == "" {
@@ -57,23 +88,30 @@ var sendCmd = &cobra.Command{
 		headers.Authorization(accessToken)
 		headers.ContentType("application/json")
 
-		// unmarshal into map
-		data := map[string]any{}
-		err := json.Unmarshal(inputData, &data)
-		if err != nil {
-			log.Error().Err(err).Msg("failed to unmarshal data to make request")
+		// unmarshal into map with specified format
+		var (
+			data = map[string]any{}
+			err  error
+		)
+		switch format {
+		case "json":
+			// NOTE: no need to convert if data is already in JSON
+		case "yaml":
+			inputData, err = yamlToJson(inputData)
+			if err != nil {
+				log.Error().Err(err)
+			}
 		}
 
 		for _, host := range args {
 			host, err := urlx.Sanitize(host)
 			if err != nil {
-				log.Error().Err(err).Msg("failed to sanitize host")
+				log.Warn().Err(err).Str("host", host).Msg("could not sanitize host")
 			}
 
 			smdClient.URI = host
 			err = smdClient.Add(inputData, headers)
 			if err != nil {
-
 				// try updating instead
 				if forceUpdate {
 					smdClient.Xname = data["ID"].(string)
@@ -90,9 +128,31 @@ var sendCmd = &cobra.Command{
 }
 
 func init() {
-	sendCmd.Flags().StringSliceVarP(&sendData, "data", "d", []string{}, "Set the data to send to specified host.")
+	sendCmd.Flags().StringSliceVarP(&sendDataArgs, "data", "d", []string{}, "Set the data in to send to specified host.")
+	sendCmd.Flags().StringVarP(&format, "format", "F", "json", "Set the data input format. (json|yaml)")
 	sendCmd.Flags().BoolVarP(&forceUpdate, "force-update", "f", false, "Set flag to force update data sent to SMD.")
 	sendCmd.Flags().StringVar(&cacertPath, "cacert", "", "Set the path to CA cert file. (defaults to system CAs when blank)")
 
 	rootCmd.AddCommand(sendCmd)
+}
+
+func yamlToJson(input []byte) ([]byte, error) {
+	var (
+		data   map[string]any
+		output []byte
+		err    error
+	)
+
+	// unmarshal YAML contents into map
+	err = yaml.Unmarshal(input, &data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal YAML input data")
+	}
+
+	// marshal map into JSON
+	output, err = json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal input data to JSON: %v", err)
+	}
+	return output, nil
 }

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+
+	urlx "github.com/OpenCHAMI/magellan/internal/url"
+	"github.com/OpenCHAMI/magellan/pkg/auth"
+	"github.com/OpenCHAMI/magellan/pkg/client"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var sendData []string
+
+var sendCmd = &cobra.Command{
+	Use: "send [host]",
+	Example: `  // send data from collect output
+  magellan send -d @collected-1.json -d @collected-2.json https://smd.openchami.cluster
+  magellan send -d '{...}' -d @collected-1.json https://api.exampe.com
+	`,
+	Short: "Send collected node information to specified host.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// concatenate all of the data from `-d` flag to send
+		var (
+			smdClient = &client.SmdClient{Client: &http.Client{}}
+			inputData = []byte(strings.Join(sendData, "\n"))
+		)
+
+		// try to load access token either from env var, file, or config if var not set
+		if accessToken == "" {
+			var err error
+			accessToken, err = auth.LoadAccessToken(tokenPath)
+			if err != nil && verbose {
+				log.Warn().Err(err).Msgf("could not load access token")
+			}
+		}
+
+		// try and load cert if argument is passed
+		if cacertPath != "" {
+			cacert, err := os.ReadFile(cacertPath)
+			if err != nil {
+				log.Warn().Err(err).Msg("failed to read cert path")
+			}
+			certPool := x509.NewCertPool()
+			certPool.AppendCertsFromPEM(cacert)
+			// smdClient.WithCertPool(certPool)
+			// client.WithCertPool(smdClient, certPool)
+		}
+
+		// create and set headers for request
+		headers := client.HTTPHeader{}
+		headers.Authorization(accessToken)
+		headers.ContentType("application/json")
+
+		// unmarshal into map
+		data := map[string]any{}
+		err := json.Unmarshal(inputData, &data)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to unmarshal data to make request")
+		}
+
+		for _, host := range args {
+			host, err := urlx.Sanitize(host)
+			if err != nil {
+				log.Error().Err(err).Msg("failed to sanitize host")
+			}
+
+			smdClient.URI = host
+			err = smdClient.Add(inputData, headers)
+			if err != nil {
+
+				// try updating instead
+				if forceUpdate {
+					smdClient.Xname = data["ID"].(string)
+					err = smdClient.Update(inputData, headers)
+					if err != nil {
+						log.Error().Err(err).Msgf("failed to forcibly update Redfish endpoint")
+					}
+				} else {
+					log.Error().Err(err).Msgf("failed to add Redfish endpoint")
+				}
+			}
+		}
+	},
+}
+
+func init() {
+	sendCmd.Flags().StringSliceVarP(&sendData, "data", "d", []string{}, "Set the data to send to specified host.")
+	sendCmd.Flags().BoolVarP(&forceUpdate, "force-update", "f", false, "Set flag to force update data sent to SMD.")
+	sendCmd.Flags().StringVar(&cacertPath, "cacert", "", "Set the path to CA cert file. (defaults to system CAs when blank)")
+
+	rootCmd.AddCommand(sendCmd)
+}

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -1,6 +1,7 @@
 scan:
   hosts:
     - "172.16.1.15"
+    - "10.0.0.1"
   subnets:
     - "172.16.0.0"
     - "172.16.0.0/24"
@@ -13,8 +14,6 @@ scan:
   protocol: "tcp"
   scheme: "https"
 collect:
-  username: "admin"
-  password: "password"
   protocol: "tcp"
   scheme: "https"
   output: "/tmp/magellan/data/"
@@ -24,8 +23,6 @@ collect:
 update:
   host:
   port: 443
-  username: "admin"
-  password: "password"
   transfer-protocol: "https"
   firmware:
     url:
@@ -36,5 +33,5 @@ update:
 concurrency: 1
 timeout: 30
 verbose: true
-db:
+cache:
   path: "/tmp/magellan/magellan.db"

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 require (
 	github.com/rs/zerolog v1.33.0
 	golang.org/x/crypto v0.32.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -56,5 +57,4 @@ require (
 	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"os/user"
 	"time"
 )
 
@@ -24,4 +25,12 @@ func CheckUntil(interval time.Duration, timeout time.Duration, predicate func() 
 			return fmt.Errorf("timeout of %ds reached", int64(timeout/time.Second))
 		}
 	}
+}
+
+func GetCurrentUsername() string {
+	currentUser, _ := user.Current()
+	if currentUser != nil {
+		return currentUser.Username
+	}
+	return ""
 }

--- a/pkg/client/default.go
+++ b/pkg/client/default.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 )
 
-type MagellanClient struct {
+type DefaultClient struct {
 	*http.Client
 }
 
-func (c *MagellanClient) Name() string {
+func (c *DefaultClient) Name() string {
 	return "default"
 }
 
@@ -18,7 +18,7 @@ func (c *MagellanClient) Name() string {
 // the first argument with no data processing or manipulation. The function sends
 // the data to a set callback URL (which may be changed to use a configurable value
 // instead).
-func (c *MagellanClient) Add(data HTTPBody, headers HTTPHeader) error {
+func (c *DefaultClient) Add(data HTTPBody, headers HTTPHeader) error {
 	if data == nil {
 		return fmt.Errorf("no data found")
 	}
@@ -35,7 +35,7 @@ func (c *MagellanClient) Add(data HTTPBody, headers HTTPHeader) error {
 	return err
 }
 
-func (c *MagellanClient) Update(data HTTPBody, headers HTTPHeader) error {
+func (c *DefaultClient) Update(data HTTPBody, headers HTTPHeader) error {
 	if data == nil {
 		return fmt.Errorf("no data found")
 	}

--- a/pkg/collect.go
+++ b/pkg/collect.go
@@ -205,26 +205,19 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams) ([]map[strin
 
 				// write data to file if output path is set using set format
 				if outputPath != "" {
-					switch params.Format {
-					case "hive":
-						var (
-							finalPath = fmt.Sprintf("./%s/%s/%d.json", outputPath, data["ID"], time.Now().Unix())
-							finalDir  = filepath.Dir(finalPath)
-						)
-						// if it doesn't, make the directory and write file
-						err = os.MkdirAll(finalDir, 0o777)
-						if err == nil { // no error
-							err = os.WriteFile(path.Clean(finalPath), body, os.ModePerm)
-							if err != nil {
-								log.Error().Err(err).Msgf("failed to write collect output to file")
-							}
-						} else { // error is set
-							log.Error().Err(err).Msg("failed to make directory for collect output")
+					var (
+						finalPath = fmt.Sprintf("./%s/%s/%d.json", outputPath, data["ID"], time.Now().Unix())
+						finalDir  = filepath.Dir(finalPath)
+					)
+					// if it doesn't, make the directory and write file
+					err = os.MkdirAll(finalDir, 0o777)
+					if err == nil { // no error
+						err = os.WriteFile(path.Clean(finalPath), body, os.ModePerm)
+						if err != nil {
+							log.Error().Err(err).Msgf("failed to write collect output to file")
 						}
-					case "json":
-					case "yaml":
-
-					default:
+					} else { // error is set
+						log.Error().Err(err).Msg("failed to make directory for collect output")
 					}
 				}
 

--- a/pkg/crawler/main.go
+++ b/pkg/crawler/main.go
@@ -126,17 +126,17 @@ func CrawlBMCForSystems(config CrawlerConfig) ([]InventoryDetail, error) {
 
 	// Obtain the ServiceRoot
 	rf_service := client.GetService()
-	log.Info().Msgf("found ServiceRoot %s. Redfish Version %s", rf_service.ID, rf_service.RedfishVersion)
+	log.Debug().Msgf("found ServiceRoot %s. Redfish Version %s", rf_service.ID, rf_service.RedfishVersion)
 
 	// Nodes are sometimes only found under Chassis, but they should be found under Systems.
 	rf_chassis, err := rf_service.Chassis()
 	if err == nil {
-		log.Info().Msgf("found %d chassis in ServiceRoot", len(rf_chassis))
+		log.Debug().Msgf("found %d chassis in ServiceRoot", len(rf_chassis))
 		for _, chassis := range rf_chassis {
 			rf_chassis_systems, err := chassis.ComputerSystems()
 			if err == nil {
 				rf_systems = append(rf_systems, rf_chassis_systems...)
-				log.Info().Msgf("found %d systems in chassis %s", len(rf_chassis_systems), chassis.ID)
+				log.Debug().Msgf("found %d systems in chassis %s", len(rf_chassis_systems), chassis.ID)
 			}
 		}
 	}
@@ -144,7 +144,7 @@ func CrawlBMCForSystems(config CrawlerConfig) ([]InventoryDetail, error) {
 	if err != nil {
 		log.Error().Err(err).Msg("failed to get systems from ServiceRoot")
 	}
-	log.Info().Msgf("found %d systems in ServiceRoot", len(rf_root_systems))
+	log.Debug().Msgf("found %d systems in ServiceRoot", len(rf_root_systems))
 	rf_systems = append(rf_systems, rf_root_systems...)
 	return walkSystems(rf_systems, nil, config.URI)
 }
@@ -202,7 +202,7 @@ func CrawlBMCForManagers(config CrawlerConfig) ([]Manager, error) {
 
 	// Obtain the ServiceRoot
 	rf_service := client.GetService()
-	log.Info().Msgf("found ServiceRoot %s. Redfish Version %s", rf_service.ID, rf_service.RedfishVersion)
+	log.Debug().Msgf("found ServiceRoot %s. Redfish Version %s", rf_service.ID, rf_service.RedfishVersion)
 
 	rf_managers, err := rf_service.Managers()
 	if err != nil {


### PR DESCRIPTION
This PR splits the `collect` command into two: `collect` and `send`. The motivation here is to create an intermediate step between collecting the inventory data and making a request to the specified host. This allows for users to customize the data being send to SMD such as the xname or MAC address before sending to SMD. Otherwise, the output of `collect` and be piped into `send` to maintain the original behavior of `collect`.


The complete dynamic discovery workflow with secrets would look something like this:

1. Scan a subnet (or subnets) to find BMC nodes.

```bash
magellan scan --subnet 172.19.0.0/24 --port 5000 --cache ./assets.db
``` 

2. After finding devices, add secrets information (we could do this as first step too). NOTE: This will change in to near future.

```bash
export MASTER_KEY=(magellan secrets generatekey)
magellan secrets store default root:root_password # saves  to secrets.json
```

3. Collect inventory from discovered nodes and redirect to file (this currently requires the `--verbose/-v` flag). The `--format/-F` flag will write the output either as JSON (`-F=json`) or YAML (`-F=yaml`).

```bash
magellan collect -F yaml -v > nodes.json

# ...alternatively, we can still make a request here with the `--host` flag
magellan collect --host https://foobar.openchami.cluster:8443
```

4. Edit the data in the `nodes.json` file.

5.a. Send the data to SMD with the new `send` command. The send command takes either the JSON output directly from `collect` or a file specified with the @ symbol similar to `curl`. It takes a single positional argument for the host. 
```bash
magellan send -d$(cat node.json) https:/foobar.openchami.cluster:8443
#...alternatively...
magellan send -d@nodes.json https://smd.openchami.cluster:27779

```

5.b. Send the data to SMD by piping the `collect` output into the `send` input. Make sure to specify the format with `--format/-F` if using YAML.

```bash
magellan collect | magellan send https://foobar.openchami.cluster:8443
magellan collect -F yaml | magellan send -F yaml https://foobar.openchami.cluster:8443
```

Once the workflow is complete, you should receive a 201 response from SMD stating that the new `RedfishEndpoint`s were created successfully.