### PR TITLE
#92 FindMACAddressWithIP expects Host IP without prefix, but is always true

### DIFF
--- a/pkg/collect.go
+++ b/pkg/collect.go
@@ -167,9 +167,14 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams) ([]map[strin
 
 				// optionally, add the MACAddr property if we find a matching IP
 				// from the correct ethernet interface
-				mac, err := FindMACAddressWithIP(config, net.ParseIP(sr.Host))
+				host := sr.Host
+				str_protocol := "https://"
+				if strings.Contains(host, str_protocol) {
+					host = strings.TrimPrefix(sr.Host, str_protocol)
+				}
+				mac, err := FindMACAddressWithIP(config, net.ParseIP(host))
 				if err != nil {
-					log.Warn().Err(err).Msgf("failed to find MAC address with IP '%s'", sr.Host)
+					log.Warn().Err(err).Msgf("failed to find MAC address with IP '%s'", host)
 				}
 				if mac != "" {
 					data["MACAddr"] = mac


### PR DESCRIPTION
In my test with against OpenBMC servers the scan function gives a result like this:

```
$ sqlite3 data/assets.db 
SQLite version 3.26.0 2018-12-01 12:34:55
Enter ".help" for usage hints.
sqlite> SELECT * FROM magellan_scanned_assets;
https://192.168.45.86|443|tcp|1|2025-04-25 16:31:34.732021656+02:00
https://192.168.45.91|443|tcp|1|2025-04-25 16:31:34.732903915+02:00
...
```

Then in function CollectInventory calling `FindMACAddressWithIP` fails because expects an argument like `192.168.45.86` not  `https://192.168.45.86` . 
This change fixes that problem.

My only concern is: This is the correct place to fix it or it will better in the "scan" fucntion, where the database is generated?