### PR TITLE
Add Output Needed for Power Control 

### DIFF
--- a/pkg/crawler/main.go
+++ b/pkg/crawler/main.go
@@ -279,12 +279,12 @@ func walkSystems(rf_systems []*redfish.ComputerSystem, rf_chassis *redfish.Chass
 				Msg("failed to get manager for system")
 		} else {
 			for _, manager := range rf_managers {
-				managerLinks = append(managerLinks, manager.ID)
+				managerLinks = append(managerLinks, manager.ODataID)
 			}
 		}
 
 		if rf_chassis != nil {
-			chassisLinks = append(chassisLinks, rf_chassis.ID)
+			chassisLinks = append(chassisLinks, rf_chassis.ODataID)
 		}
 
 		// get all of the links to the chassis

--- a/pkg/crawler/main.go
+++ b/pkg/crawler/main.go
@@ -65,9 +65,9 @@ type Links struct {
 }
 
 type Power struct {
-	State         string
-	Mode          string
-	RestorePolicy string
+	State         string `json:"state,omitempty"`
+	Mode          string `json:"mode,omitempty"`
+	RestorePolicy string `json:"restore_policy"`
 }
 
 type InventoryDetail struct {


### PR DESCRIPTION
This PR adds more details to the `collect` command's output. Specifically, it adds some power settings (only via Redfish), actions, and system links from Redfish endpoints `/redfish/v1/Systems`, `/redfish/v1/Systems/{id}/Links`, and `/redfish/v1/Systems/Actions`. The snippet of the output looks like the following (output reduced for brevity):

```bash
{
        [...snip...]
            {
                "uri": "https://172.16.0.101:443/redfish/v1/Systems/1",
                "uuid": "...",
                "manufacturer": "HPE",
                "system_type": "Physical",
                "name": "Computer System",
                "model": "...",
                "serial": "...",
                "bios_version": "A43 v2.90 (10/27/2023)",
                "ethernet_interfaces": [
                    [...snip...]
                ],
                "network_interfaces": [
                    [...snip...]
                ],
                "power": {
                    "state": "Off",
                    "restore_policy": ""
                },
                "processor_count": 1,
                "processor_type": "AMD EPYC 7713P 64-Core Processor               ",
                "memory_total": 256,
                "trusted_modules": [
                    "TPM2_0 73.64"
                ],
"actions": [
        "On",
        "ForceOff",
        "GracefulShutdown",
        "ForceRestart",
        "Nmi",
        "PushPowerButton",
        "GracefulRestart"
      ],
                "links": {
                    "managers": [
                        "/redfish/v1/Managers/1/"
                    ]
                }
            }
        ],
        "Type": "",
        "User": "Administrator"
    }

```

To test this PR:

1. Clone and checkout branch:

```bash
git clone https://github.com/OpenCHAMI/magellan.git
cd magellan
git checkout power-control-output && go build
```
2. Set secrets using secret store

```bash
export MASTER_KEY=$(magellan secrets generatekey)
./magellan secrets store $host $username:$password
```

3.a. Perform a crawl

```bash
./magellan crawl -i $host -u $username -p $password
```
3.b. Perform a scan (optional if using crawler)

```bash
./magellan scan --subnet 172.16.0.0/24
```

4. Perform a collect
```bash
./magellan collect -v
```

You should see a "power", "actions", and "links" field included in the output.
