### PR TITLE
Replace generated xname BMC IDs with BMC Address to BMC ID mapping

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,7 @@ var (
 	debug       bool
 	forceUpdate bool
 	insecure    bool
+	idMapPath   string
 )
 
 // The `root` command doesn't do anything on it's own except display

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/OpenCHAMI/magellan
 go 1.21
 
 require (
-	github.com/Cray-HPE/hms-xname v1.3.0
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/jmoiron/sqlx v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
-github.com/Cray-HPE/hms-xname v1.3.0 h1:DQmetMniubqcaL6Cxarz9+7KFfWGSEizIhfPHIgC3Gw=
-github.com/Cray-HPE/hms-xname v1.3.0/go.mod h1:XKdjQSzoTps5KDOE8yWojBTAWASGaS6LfRrVDxwTQO8=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 h1:iwZdTE0PVqJCos1vaoKsclOGD3ADKpshg3SRtYBbwso=

--- a/pkg/collect.go
+++ b/pkg/collect.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/Cray-HPE/hms-xname/xnames"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stmcginnis/gofish"
 	"github.com/stmcginnis/gofish/redfish"
@@ -41,7 +40,17 @@ type CollectParams struct {
 	Format      string              // set the output format
 	ForceUpdate bool                // set whether to force updating SMD with 'force-update' flag
 	AccessToken string              // set the access token to include in request with 'access-token' flag
+	BMCIdMap   string              // Set the path to the BMC ID mapping YAML or JSON file (if any)
 	SecretStore secrets.SecretStore // set BMC credentials
+}
+
+// BMCIdMap contains the mapping of host address strings to BMC Identifiers
+// supplied by the --bmc-id-map option to collect. IdMap is the mapping itself,
+// MapKey specifies what string to use as the key to the map. For now, that is
+// always 'bmc-ip-addr'. In the future other options may be available.
+type BMCIdMap struct {
+	IdMap      map[string]string `json:"id_map" yaml:"id_map"`
+	MapKey     string `json:"map_key" yaml:"map_key"`
 }
 
 // This is the main function used to collect information from the BMC nodes via Redfish.
@@ -61,13 +70,28 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams) ([]map[strin
 
 	// collect bmc information asynchronously
 	var (
-		offset     = 0
 		wg         sync.WaitGroup
 		collection = make([]map[string]any, 0)
 		found      = make([]string, 0, len(*assets))
 		done       = make(chan struct{}, params.Concurrency+1)
 		chanAssets = make(chan RemoteAsset, params.Concurrency+1)
+		bmcIdMap   *BMCIdMap
+		err        error
 	)
+	// Get the host to BMC ID mapping
+	bmcIdMap, err = getBMCIdMap(params.BMCIdMap, params.Format)
+	if err != nil {
+		return nil, err
+	}
+	// Validate the MapKey field in the ID Map (the only value
+	// currently allowed is 'bmc-ip-addr', but this is where
+	// any other legal values would be added).
+	switch bmcIdMap.MapKey {
+	case "bmc-ip-addr":
+		break
+	default:
+		return nil, fmt.Errorf("invalid 'map_key' field '%s' in BMC ID Map avalid value is 'bmc-ip-addr", bmcIdMap.MapKey)
+	}
 
 	// set the client's params from CLI
 	wg.Add(params.Concurrency)
@@ -80,18 +104,17 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams) ([]map[strin
 					return
 				}
 
-				// generate custom xnames for bmcs
-				// TODO: add xname customization via CLI
-				var (
-					uri  = fmt.Sprintf("%s:%d", sr.Host, sr.Port)
-					node = xnames.Node{
-						Cabinet:       1000,
-						Chassis:       1,
-						ComputeModule: 7,
-						NodeBMC:       offset,
-					}
-				)
-				offset += 1
+				trimmedHost := strings.TrimPrefix(sr.Host, "https://")
+				uri  := fmt.Sprintf("%s:%d", sr.Host, sr.Port)
+				bmcId := getBMCId(bmcIdMap, trimmedHost)
+
+				// If bmcId is empty, skip this BMC. Empty means that there
+				// is a valid mapping, but there was no match for this host
+				// in the mapping, meaning that the BMC is unrecognized. Skip
+				// this BMC.
+				if bmcId == "" {
+					continue
+				}
 
 				// crawl BMC node to fetch inventory data via Redfish
 				var (
@@ -103,7 +126,6 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams) ([]map[strin
 						Insecure:        true,
 						UseDefault:      true,
 					}
-					err error
 				)
 
 				// crawl for node and BMC information
@@ -129,7 +151,7 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams) ([]map[strin
 
 				// data to be sent to smd
 				data := map[string]any{
-					"ID":                 fmt.Sprintf("%v", node.String()[:len(node.String())-2]),
+					"ID":                 bmcId,
 					"Type":               "",
 					"Name":               "",
 					"FQDN":               strings.TrimPrefix(sr.Host, "https://"),
@@ -198,7 +220,6 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams) ([]map[strin
 
 	var (
 		output []byte
-		err    error
 	)
 
 	// format our output to write to file or standard out
@@ -333,4 +354,88 @@ func FindMACAddressWithIP(config crawler.CrawlerConfig, targetIP net.IP) (string
 
 	// no matches found, so return an empty string
 	return "", fmt.Errorf("no ethernet interfaces found with IP address")
+}
+
+func getBMCIdMap(data string, format string)(*BMCIdMap, error) {
+	// If no mapping is provided, there is no error, but there is
+	// also no mapping, just return nil with no error and let the
+	// caller pass that around.
+	if data == "" {
+		return nil, nil
+	}
+
+	var bmcIdMap BMCIdMap
+	// First, check whether 'data' specifies a file (i.e. starts
+	// with '@'). If not, it should be a JSON string containing the
+	// map data. Otherwise, strip the '@' and fall through.
+	if data[0] != '@' {
+		err := json.Unmarshal([]byte(data), &bmcIdMap)
+		if err != nil {
+			return nil, err
+		}
+		return &bmcIdMap, nil
+	}
+
+	// The map data is in a file. Get the path from what comes
+	// after the '@' and process it.
+	path := data[1:]
+
+	// Read in the contents of the map file, since we are going to
+	// do that no matter what type it is...
+	input, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading BMC ID mapping file '%s': %v", path, err)
+	}
+
+	// Figure out the type of the contents (JSON or YAML) based on
+	// the filname extension. By default the format is passed in,
+	// so if it doesn't match one of the cases, that's what we
+	// will use.
+	ext := filepath.Ext(path)
+	switch ext {
+	case ".json":
+		// The file is a JSON file
+		format = "json"
+	case ".yaml", ".yml":
+		// The file is a YAML file
+		format = "yaml"
+	}
+
+	// Decode the file based on the chosen format.
+	switch format {
+	case "json":
+		// Read in JSON file
+		err := json.Unmarshal(input, &bmcIdMap)
+		if err != nil {
+			return nil, err
+		}
+	case "yaml":
+		// Read in YAML file
+		err := yaml.Unmarshal(input, &bmcIdMap)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &bmcIdMap, nil
+}
+
+// Generate a BMC ID string associated with 'selector' in the provided
+// 'BMCIdMap'. If there is no map, then return the selector string
+// itself.  If the map is present but the host is not present in the
+// map, then log a warning and return an empty string indicating that
+// the BMC ID was not composed.
+func getBMCId(bmcIdMap *BMCIdMap, selector string) (string) {
+	if bmcIdMap == nil {
+		return selector
+	}
+	// Go does not error out on string map references that do not
+	// match the selector, it simply produces an empty
+	// string. Recognize that case and log it, then return an
+	// empty string.
+	bmcId := bmcIdMap.IdMap[selector]
+	if bmcId == "" {
+		log.Warn().Msgf("no mapping found from host selector '%v' to a BMC ID", selector)
+		return ""
+	}
+	return bmcId
 }


### PR DESCRIPTION
This PR addresses issue #106. For details on the discussion that led to the current implementation, see that issue.

The question it answers is how to produce useful values for the ID field of a BMC structure given to a consumer of `magellan collect` results. The current implementation conjurs an xname to be used as the ID of each BMC it finds. There are a few problems with this approach:

- xnames are HPE/Cray vendor specific IDs meaningful only within the SMD framework.
- on-the-fly generated xnames only serve as IDs but not as locators as xnames are expected to do in the SMD framework
- on-the-fly generated xnames are not repeatable with subsequent `magellan collect` runs leading to potentially incorrect data updates.

This PR implements a mechanism that allows a vendor or integrator of magellan to supply a mapping between the BMC (represented currently by its discovered IP address) and an ID value (a valid xname if the consumer is SMD, something else if the consumer is not). This mapping can be supplied as JSON data on the command line or in a YAML or JSON file. If no mapping is provided, the ID value produced  is the IP address string used to discover the BMC.

This allows systems that use the SMD framework to map BMCs onto xnames accurately. It allows vendors or integrators of systems with different consumers to map BMCs on whatever is appropriate to their consumers, and it removes the HPE/Cray specific knowledge of xnames from the `magellan collect` code. In the default case, the identifier produced by this approach is repeatable and locally unique, and does not require any special handling to achieve those qualities.