### PR TITLE
Deduplicate crawled ComputerSystems across `Systems` and `Chassis` endpoints

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,7 +92,7 @@ func init() {
 	checkBindFlagError(viper.BindPFlag("timeout", rootCmd.PersistentFlags().Lookup("timeout")))
 	checkBindFlagError(viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose")))
 	checkBindFlagError(viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")))
-	checkBindFlagError(viper.BindPFlag("access-token", rootCmd.PersistentFlags().Lookup("verbose")))
+	checkBindFlagError(viper.BindPFlag("access-token", rootCmd.PersistentFlags().Lookup("access-token")))
 	checkBindFlagError(viper.BindPFlag("cache", rootCmd.PersistentFlags().Lookup("cache")))
 }
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 )
 
 require (
+	dario.cat/mergo v1.0.2
 	github.com/rs/zerolog v1.33.0
 	golang.org/x/crypto v0.32.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
+dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/Cray-HPE/hms-xname v1.3.0 h1:DQmetMniubqcaL6Cxarz9+7KFfWGSEizIhfPHIgC3Gw=


### PR DESCRIPTION
Magellan already accounts for a complication where some BMCs expose their ComputerSystems under `/redfish/v1/Chassis` instead of `.../Systems`.,However, the existing logic just concatenates the two sets of ComputerSystems found in this way, which is a problem if the same systems are exposed under each of the two endpoints — we end up with two entries for each system. (Confusingly, pairs entries are not actually identical; ones from the `Systems` endpoint may be missing chassis information.)

This PR adds logic to merge duplicate ComputerSystems from the two endpoints. Duplicate systems found in `Systems` are merged onto their counterparts from `Chassis`, i.e. any non-empty fields override their existing counterparts. (The `Systems` endpoint is the canonical location for ComputerSystems, so entries from there get priority.)

Also, another included commit fixes a CLI-binding typo for the access token flag.
