### PR TITLE
fix: use DB format when scanning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ To start a network scan for BMC nodes, use the `scan` command. If the port is no
 ./magellan scan \
     --subnet 172.16.0.0 \
     --subnet-mask 255.255.255.0 \
-    --format json \
     --cache data/assets.db
 ```
 


### PR DESCRIPTION
As of v0.5.0, this bit of the README was incorrect. `--format json` results in `scan` printing JSON info to stdout and _not_ saving to a cache file. Cache file saving only happens with `--format db`.

This may be a bug. I'm unsure if this is intended or not, but it aligns the README with current behavior.

https://github.com/OpenCHAMI/magellan/blob/v0.5.0/cmd/scan.go#L158-L199 switches on JSON/YAML output and DB output. Only the DB case honors the `--cache` flag. This was added in https://github.com/OpenCHAMI/magellan/commit/c413dd5649d53e36b1633f54b087713a6a05bcdb as part of a PR for other functionality.

Is that expected, or should cache save a DB regardless? If it should only save when we have `--format db`, should we abort and print an error if we see `--cache` along with `--format json`?