### PR TITLE
Separate text and DB output

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/OpenCHAMI/magellan/internal/cache/sqlite"
+	"github.com/OpenCHAMI/magellan/internal/util"
 	magellan "github.com/OpenCHAMI/magellan/pkg"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
@@ -158,9 +159,9 @@ var ScanCmd = &cobra.Command{
 			var output []byte
 			var err error
 			switch format {
-			case "json":
+			case util.FORMAT_JSON:
 				output, err = json.MarshalIndent(foundAssets, "", "  ")
-			case "yaml":
+			case util.FORMAT_YAML:
 				output, err = yaml.Marshal(foundAssets)
 			default:
 				log.Error().Msgf("unknown format specified: %s. Please use 'json', or 'yaml'.", format)

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -154,22 +154,21 @@ var ScanCmd = &cobra.Command{
 			return
 		}
 
-		switch format {
-		case "json", "yaml":
+		if format != "" {
 			var output []byte
 			var err error
-
-			if format == "json" {
+			switch format {
+			case "json":
 				output, err = json.MarshalIndent(foundAssets, "", "  ")
-			} else {
+			case "yaml":
 				output, err = yaml.Marshal(foundAssets)
+			default:
+				log.Error().Msgf("unknown format specified: %s. Please use 'json', or 'yaml'.", format)
 			}
-
 			if err != nil {
 				log.Error().Err(err).Msgf("Failed to marshal output to %s", format)
 				return
 			}
-
 			if outputPath != "" {
 				err := os.WriteFile(outputPath, output, 0644)
 				if err != nil {
@@ -180,22 +179,18 @@ var ScanCmd = &cobra.Command{
 			} else {
 				fmt.Println(string(output))
 			}
-
-		case "db":
-			if !disableCache && cachePath != "" {
-				err := os.MkdirAll(path.Dir(cachePath), 0755)
-				if err != nil {
-					log.Printf("failed to make cache directory: %v", err)
-				}
-				err = sqlite.InsertScannedAssets(cachePath, foundAssets...)
-				if err != nil {
-					log.Error().Err(err).Msg("failed to write scanned assets to cache")
-				} else if verbose {
-					log.Info().Msgf("Saved assets to cache: %s", cachePath)
-				}
+		}
+		if !disableCache && cachePath != "" {
+			err := os.MkdirAll(path.Dir(cachePath), 0755)
+			if err != nil {
+				log.Printf("failed to make cache directory: %v", err)
 			}
-		default:
-			log.Error().Msgf("unknown format specified: %s. Please use 'db', 'json', or 'yaml'.", format)
+			err = sqlite.InsertScannedAssets(cachePath, foundAssets...)
+			if err != nil {
+				log.Error().Err(err).Msg("failed to write scanned assets to cache")
+			} else if verbose {
+				log.Info().Msgf("Saved assets to cache: %s", cachePath)
+			}
 		}
 
 	},
@@ -210,7 +205,7 @@ func init() {
 	ScanCmd.Flags().BoolVar(&disableProbing, "disable-probing", false, "Disable probing found assets for Redfish service(s) running on BMC nodes")
 	ScanCmd.Flags().BoolVar(&disableCache, "disable-cache", false, "Disable saving found assets to a cache database specified with 'cache' flag")
 	ScanCmd.Flags().BoolVar(&insecure, "insecure", true, "Skip TLS certificate verification during probe")
-	ScanCmd.Flags().StringVarP(&format, "format", "F", "db", "Output format (db, json, yaml)")
+	ScanCmd.Flags().StringVarP(&format, "format", "F", "", "Output format (json, yaml)")
 	ScanCmd.Flags().StringVarP(&outputPath, "output", "o", "", "Output file path (for json/yaml formats)")
 	ScanCmd.Flags().StringSliceVar(&include, "include", []string{"bmcs"}, "Asset types to scan for (bmcs, pdus)")
 


### PR DESCRIPTION
Implements the proposed change from https://github.com/OpenCHAMI/magellan/issues/119 and makes the `--format` and `--cache` flags for `magellan scan` independent rather than de facto mutually exclusive.

* Removes `db` as a supported format.
* Extracts the original `db` case under format into a separate block gated by `--disable-cache`
* Extracts common steps (error checking and writing) from format-specific steps (marshaling) in the format handler block.

Manual testing: [test.txt](https://github.com/user-attachments/files/21977325/test.txt)

Fix #119 