### PR TITLE
Address and fix `golangci-lint` issues

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -160,7 +160,9 @@ func init() {
 	CollectCmd.Flags().StringVarP(&idMap, "bmc-id-map", "m", "", "Set the BMC ID mapping from raw json data or use @<path> to specify a file path (json or yaml input)")
 
 	CollectCmd.MarkFlagsMutuallyExclusive("output-file", "output-dir")
-	_ = CollectCmd.RegisterFlagCompletionFunc("format", completionFormatData)
+
+	// register completion flag functions
+	checkRegisterFlagCompletionError(CollectCmd.RegisterFlagCompletionFunc("format", completionFormatData))
 
 	// bind flags to config properties
 	checkBindFlagError(viper.BindPFlag("collect.protocol", CollectCmd.Flags().Lookup("protocol")))

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -103,7 +103,10 @@ var CollectCmd = &cobra.Command{
 						if newCreds, err := json.Marshal(creds); err != nil {
 							log.Error().Str("id", k).Err(err).Msg("failed to override BMC credentials: marshal error")
 						} else {
-							s.StoreSecretByID(k, string(newCreds))
+							err = s.StoreSecretByID(k, string(newCreds))
+							if err != nil {
+								log.Error().Err(err).Str("id", k).Msg("failed to store secret by ID")
+							}
 						}
 					}
 				}
@@ -157,7 +160,7 @@ func init() {
 	CollectCmd.Flags().StringVarP(&idMap, "bmc-id-map", "m", "", "Set the BMC ID mapping from raw json data or use @<path> to specify a file path (json or yaml input)")
 
 	CollectCmd.MarkFlagsMutuallyExclusive("output-file", "output-dir")
-	CollectCmd.RegisterFlagCompletionFunc("format", completionFormatData)
+	_ = CollectCmd.RegisterFlagCompletionFunc("format", completionFormatData)
 
 	// bind flags to config properties
 	checkBindFlagError(viper.BindPFlag("collect.protocol", CollectCmd.Flags().Lookup("protocol")))

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -153,7 +153,7 @@ func init() {
 	CrawlCmd.Flags().BoolVar(&showOutput, "show", false, "Show the output of a collect run")
 	CrawlCmd.Flags().VarP(&crawlOutputFormat, "format", "F", "Set the output format (json|yaml)")
 
-	_ = CrawlCmd.RegisterFlagCompletionFunc("format", completionFormatData)
+	checkRegisterFlagCompletionError(CrawlCmd.RegisterFlagCompletionFunc("format", completionFormatData))
 
 	checkBindFlagError(viper.BindPFlag("crawl.insecure", CrawlCmd.Flags().Lookup("insecure")))
 

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -153,7 +153,7 @@ func init() {
 	CrawlCmd.Flags().BoolVar(&showOutput, "show", false, "Show the output of a collect run")
 	CrawlCmd.Flags().VarP(&crawlOutputFormat, "format", "F", "Set the output format (json|yaml)")
 
-	CrawlCmd.RegisterFlagCompletionFunc("format", completionFormatData)
+	_ = CrawlCmd.RegisterFlagCompletionFunc("format", completionFormatData)
 
 	checkBindFlagError(viper.BindPFlag("crawl.insecure", CrawlCmd.Flags().Lookup("insecure")))
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -54,7 +54,7 @@ func init() {
 	ListCmd.Flags().VarP(&listOutputFormat, "format", "F", "Set the output format (list|json|yaml)")
 	ListCmd.Flags().BoolVar(&showCache, "cache-info", false, "Show cache information and exit")
 
-	_ = ListCmd.RegisterFlagCompletionFunc("format", completionFormatData)
+	checkRegisterFlagCompletionError(ListCmd.RegisterFlagCompletionFunc("format", completionFormatData))
 
 	rootCmd.AddCommand(ListCmd)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -43,7 +43,8 @@ var ListCmd = &cobra.Command{
 
 		output, err := format.MarshalData(scannedResults, listOutputFormat)
 		if err != nil {
-
+			log.Error().Err(err).Msg("failed to marshal data")
+			return
 		}
 		log.Printf(string(output))
 	},
@@ -53,7 +54,7 @@ func init() {
 	ListCmd.Flags().VarP(&listOutputFormat, "format", "F", "Set the output format (list|json|yaml)")
 	ListCmd.Flags().BoolVar(&showCache, "cache-info", false, "Show cache information and exit")
 
-	ListCmd.RegisterFlagCompletionFunc("format", completionFormatData)
+	_ = ListCmd.RegisterFlagCompletionFunc("format", completionFormatData)
 
 	rootCmd.AddCommand(ListCmd)
 }

--- a/cmd/power.go
+++ b/cmd/power.go
@@ -250,7 +250,7 @@ func init() {
 	PowerCmd.Flags().String("cacert", "", "Set the path to CA cert file (defaults to system CAs when blank)")
 	PowerCmd.Flags().VarP(&powerFormat, "format", "F", "Set the output format (json|yaml)")
 
-	_ = PowerCmd.RegisterFlagCompletionFunc("format", completionFormatData)
+	checkRegisterFlagCompletionError(PowerCmd.RegisterFlagCompletionFunc("format", completionFormatData))
 
 	// Bind flags to config properties
 	checkBindFlagError(viper.BindPFlag("power.cacert", PowerCmd.Flags().Lookup("cacert")))

--- a/cmd/power.go
+++ b/cmd/power.go
@@ -107,7 +107,10 @@ var PowerCmd = &cobra.Command{
 						if newCreds, err := json.Marshal(creds); err != nil {
 							log.Error().Str("id", k).Err(err).Msg("failed to override BMC credentials: marshal error")
 						} else {
-							s.StoreSecretByID(k, string(newCreds))
+							err = s.StoreSecretByID(k, string(newCreds))
+							if err != nil {
+								log.Error().Err(err).Str("id", k).Msg("failed to store secret by ID")
+							}
 						}
 					}
 				}
@@ -247,7 +250,7 @@ func init() {
 	PowerCmd.Flags().String("cacert", "", "Set the path to CA cert file (defaults to system CAs when blank)")
 	PowerCmd.Flags().VarP(&powerFormat, "format", "F", "Set the output format (json|yaml)")
 
-	PowerCmd.RegisterFlagCompletionFunc("format", completionFormatData)
+	_ = PowerCmd.RegisterFlagCompletionFunc("format", completionFormatData)
 
 	// Bind flags to config properties
 	checkBindFlagError(viper.BindPFlag("power.cacert", PowerCmd.Flags().Lookup("cacert")))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,6 +117,12 @@ func checkBindFlagError(err error) {
 	}
 }
 
+func checkRegisterFlagCompletionError(err error) {
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to register completion function")
+	}
+}
+
 func helpMapToSlice(help map[string]string) []string {
 	var helpSlice []string
 	for k, v := range help {

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -160,17 +160,18 @@ var secretsStoreCmd = &cobra.Command{
 
 func isValidCredsJSON(val string) bool {
 	var (
-		valid = !json.Valid([]byte(val))
-		creds map[string]string
-		err   error
+		validUsername bool
+		validPassword bool
+		creds         map[string]string
+		err           error
 	)
 	err = json.Unmarshal([]byte(val), &creds)
 	if err != nil {
 		return false
 	}
-	_, valid = creds["username"]
-	_, valid = creds["password"]
-	return valid
+	_, validUsername = creds["username"]
+	_, validPassword = creds["password"]
+	return !json.Valid([]byte(val)) && validUsername && validPassword
 }
 
 var secretsRetrieveCmd = &cobra.Command{
@@ -243,7 +244,10 @@ var secretsRemoveCmd = &cobra.Command{
 			}
 
 			// update store by saving to original file
-			secrets.SaveSecrets(secretsFile, store.(*secrets.LocalSecretStore).Secrets)
+			err = secrets.SaveSecrets(secretsFile, store.(*secrets.LocalSecretStore).Secrets)
+			if err != nil {
+				log.Error().Err(err).Str("path", secretsFile).Msg("failed to save secrets to file")
+			}
 		}
 	},
 }

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -128,7 +128,7 @@ func init() {
 	sendCmd.Flags().BoolVarP(&forceUpdate, "force-update", "f", false, "Set flag to force update data sent to SMD")
 	sendCmd.Flags().StringVar(&cacertPath, "cacert", "", "Set the path to CA cert file (defaults to system CAs when blank)")
 
-	_ = sendCmd.RegisterFlagCompletionFunc("format", completionFormatData)
+	checkRegisterFlagCompletionError(sendCmd.RegisterFlagCompletionFunc("format", completionFormatData))
 	rootCmd.AddCommand(sendCmd)
 }
 

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -128,7 +128,7 @@ func init() {
 	sendCmd.Flags().BoolVarP(&forceUpdate, "force-update", "f", false, "Set flag to force update data sent to SMD")
 	sendCmd.Flags().StringVar(&cacertPath, "cacert", "", "Set the path to CA cert file (defaults to system CAs when blank)")
 
-	sendCmd.RegisterFlagCompletionFunc("format", completionFormatData)
+	_ = sendCmd.RegisterFlagCompletionFunc("format", completionFormatData)
 	rootCmd.AddCommand(sendCmd)
 }
 
@@ -153,7 +153,7 @@ func processDataArgs(args []string) []map[string]any {
 			// determine if we're reading from file to load contents
 			if strings.HasPrefix(arg, "@") {
 				var (
-					path     string = strings.TrimLeft(arg, "@")
+					path     = strings.TrimLeft(arg, "@")
 					contents []byte
 					data     JSONArray
 					err      error

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -13,10 +13,7 @@ import (
 )
 
 var (
-	host             string
 	firmwareUri      string
-	firmwareVersion  string
-	component        string
 	transferProtocol string
 	showStatus       bool
 	Insecure         bool

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -12,9 +12,11 @@ import (
 )
 
 // string representation that directly corresponds to zerolog.Level
-type LogLevel string
-type LogLevelList []LogLevel
-type LogFilter string
+type (
+	LogFilter    string
+	LogLevel     string
+	LogLevelList []LogLevel
+)
 
 const (
 	DEBUG    LogLevel = "debug"
@@ -70,7 +72,7 @@ func InitWithLogLevel(logLevel LogLevel, logPath string) error {
 
 	// add the default stderr writer
 	writers = append(writers, &zerolog.FilteredLevelWriter{
-		Writer: &zerolog.LevelWriterAdapter{os.Stderr},
+		Writer: &zerolog.LevelWriterAdapter{Writer: os.Stderr},
 		Level:  level,
 	})
 
@@ -83,7 +85,7 @@ func InitWithLogLevel(logLevel LogLevel, logPath string) error {
 
 		// add another write to write to the specified log file
 		writers = append(writers, &zerolog.FilteredLevelWriter{
-			Writer: zerolog.LevelWriterAdapter{LogFile},
+			Writer: zerolog.LevelWriterAdapter{Writer: LogFile},
 			Level:  level,
 		})
 	}

--- a/internal/login.go
+++ b/internal/login.go
@@ -46,7 +46,7 @@ func Login(loginUrl string, targetHost string, targetPort int) (string, error) {
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// try and extract access token from headers
 		accessToken = r.Header.Get("access_token")
-		s.Close()
+		_ = s.Close()
 	})
 	return accessToken, s.ListenAndServe()
 }

--- a/internal/login.go
+++ b/internal/login.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/pkg/browser"
+	"github.com/rs/zerolog/log"
 )
 
 // Login() initiates the process to retrieve an access token from an identity provider.
@@ -46,7 +47,10 @@ func Login(loginUrl string, targetHost string, targetPort int) (string, error) {
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// try and extract access token from headers
 		accessToken = r.Header.Get("access_token")
-		_ = s.Close()
+		err = s.Close()
+		if err != nil {
+			log.Warn().Err(err).Msg("could not close server")
+		}
 	})
 	return accessToken, s.ListenAndServe()
 }

--- a/internal/util/error.go
+++ b/internal/util/error.go
@@ -1,6 +1,9 @@
 package util
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // FormatErrorList() is a wrapper function that unifies error list formatting
 // and makes printing error lists consistent.
@@ -9,12 +12,12 @@ import "fmt"
 // Instead, it is a single condensed error composed of all of the errors included
 // in the errList argument.
 func FormatErrorList(errList []error) error {
-	var err error
+	var errmsg string
 	for i, e := range errList {
 		// NOTE: for multi-error formating, we want to include \n here
-		err = fmt.Errorf("\t[%d] %v\n", i, e)
+		errmsg = fmt.Sprintf("\t[%d] %v\n", i, e)
 	}
-	return err
+	return errors.New(errmsg)
 }
 
 // HasErrors() is a simple wrapper function to check if an error list contains

--- a/pkg/client/net.go
+++ b/pkg/client/net.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+
+	"github.com/rs/zerolog/log"
 )
 
 // HTTP aliases for readibility
@@ -72,9 +74,12 @@ func MakeRequest(client *http.Client, url string, httpMethod string, body HTTPBo
 		return nil, nil, fmt.Errorf("failed to make request: %v", err)
 	}
 	b, err := io.ReadAll(res.Body)
-	res.Body.Close()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	if err := res.Body.Close(); err != nil {
+		log.Warn().Err(err).Msg("could not close response resource")
 	}
 	return res, b, err
 }

--- a/pkg/collect.go
+++ b/pkg/collect.go
@@ -60,11 +60,11 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams) ([]map[strin
 	// collect bmc information asynchronously
 	var (
 		wg         sync.WaitGroup
-		collection              = make([]map[string]any, 0)
-		found                   = make([]string, 0, len(*assets))
-		done                    = make(chan struct{}, params.Concurrency+1)
-		chanAssets              = make(chan RemoteAsset, params.Concurrency+1)
-		mapper     idmap.Mapper = idmap.PickIDMapper(params.BMCIDMap, params.Format)
+		collection = make([]map[string]any, 0)
+		found      = make([]string, 0, len(*assets))
+		done       = make(chan struct{}, params.Concurrency+1)
+		chanAssets = make(chan RemoteAsset, params.Concurrency+1)
+		mapper     = idmap.PickIDMapper(params.BMCIDMap, params.Format)
 		err        error
 	)
 

--- a/pkg/jaws/pdu-crawler.go
+++ b/pkg/jaws/pdu-crawler.go
@@ -60,7 +60,6 @@ func CrawlPDU(config CrawlerConfig) (*pdu.PDUInventory, error) {
 		log.Error().Err(err).Msgf("failed to execute request to JAWS outlets endpoint %s", targetURL)
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		err := fmt.Errorf("received non-200 status code from outlets endpoint: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
@@ -91,6 +90,10 @@ func CrawlPDU(config CrawlerConfig) (*pdu.PDUInventory, error) {
 		inventory.Outlets = append(inventory.Outlets, outlet)
 	}
 
-	log.Info().Msgf("successfully collected inventory for %d outlets from %s", len(inventory.Outlets), config.URI)
+	if err := resp.Body.Close(); err != nil {
+		log.Warn().Err(err).Msg("could not close response resource")
+	}
+
+	log.Debug().Msgf("successfully collected inventory for %d outlets from %s", len(inventory.Outlets), config.URI)
 	return inventory, nil
 }

--- a/pkg/scan.go
+++ b/pkg/scan.go
@@ -116,13 +116,17 @@ func ScanForAssets(params *ScanParams) []RemoteAsset {
 
 								res, err := probeClient.Do(req)
 								if err == nil && res != nil && res.StatusCode == http.StatusOK {
-									res.Body.Close()
+									if err := res.Body.Close(); err != nil {
+										log.Warn().Err(err).Msg("could not close response resource")
+									}
 									foundAsset.ServiceType = probe.Type
 									assetsToAdd = append(assetsToAdd, foundAsset)
 									break // Found a valid service, no need to probe other types
 								}
 								if res != nil {
-									res.Body.Close()
+									if err := res.Body.Close(); err != nil {
+										log.Warn().Err(err).Msg("could not close response resource")
+									}
 								}
 							}
 						}
@@ -237,7 +241,9 @@ func rawConnect(address string, protocol string, timeoutSeconds int, keepOpenOnl
 	}
 	if conn != nil {
 		asset.State = true
-		defer conn.Close()
+		if err = conn.Close(); err != nil {
+			log.Warn().Err(err).Msg("could not close connection")
+		}
 	}
 	if keepOpenOnly {
 		if asset.State {

--- a/pkg/secrets/encryption.go
+++ b/pkg/secrets/encryption.go
@@ -16,8 +16,8 @@ import (
 func deriveAESKey(masterKey []byte, secretID string) []byte {
 	salt := []byte(secretID)
 	hkdf := hkdf.New(sha256.New, masterKey, salt, nil)
-	derivedKey := make([]byte, 32) // AES-256 key
-	io.ReadFull(hkdf, derivedKey)
+	derivedKey := make([]byte, 32)       // AES-256 key
+	_, _ = io.ReadFull(hkdf, derivedKey) // no need to check err here
 	return derivedKey
 }
 

--- a/pkg/secrets/localstore_test.go
+++ b/pkg/secrets/localstore_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"os"
 	"testing"
+
+	"github.com/rs/zerolog/log"
 )
 
 func TestNewLocalSecretStore(t *testing.T) {
@@ -13,7 +15,6 @@ func TestNewLocalSecretStore(t *testing.T) {
 	}
 
 	filename := "test_secrets.json"
-	defer os.Remove(filename)
 
 	store, err := NewLocalSecretStore(masterKey, filename, true)
 	if err != nil {
@@ -26,6 +27,10 @@ func TestNewLocalSecretStore(t *testing.T) {
 
 	if hex.EncodeToString(store.masterKey) != masterKey {
 		t.Errorf("Expected master key %s, got %s", masterKey, hex.EncodeToString(store.masterKey))
+	}
+
+	if err = os.Remove(filename); err != nil {
+		log.Warn().Err(err).Msg("could not close response resource")
 	}
 }
 
@@ -47,7 +52,6 @@ func TestStoreAndGetSecretByID(t *testing.T) {
 	}
 
 	filename := "test_secrets.json"
-	defer os.Remove(filename)
 
 	store, err := NewLocalSecretStore(masterKey, filename, true)
 	if err != nil {
@@ -70,6 +74,10 @@ func TestStoreAndGetSecretByID(t *testing.T) {
 	if retrievedSecret != secretValue {
 		t.Errorf("Expected secret value %s, got %s", secretValue, retrievedSecret)
 	}
+
+	if err = os.Remove(filename); err != nil {
+		log.Warn().Err(err).Msg("could not close response resource")
+	}
 }
 
 func TestStoreAndGetSecretJSON(t *testing.T) {
@@ -79,7 +87,6 @@ func TestStoreAndGetSecretJSON(t *testing.T) {
 	}
 
 	filename := "test_secrets.json"
-	defer os.Remove(filename)
 
 	store, err := NewLocalSecretStore(masterKey, filename, true)
 	if err != nil {
@@ -101,6 +108,9 @@ func TestStoreAndGetSecretJSON(t *testing.T) {
 	if retrieved != jsonSecret {
 		t.Errorf("Expected %s, got %s", jsonSecret, retrieved)
 	}
+	if err = os.Remove(filename); err != nil {
+		log.Warn().Err(err).Msg("could not close response resource")
+	}
 }
 
 func TestListSecrets(t *testing.T) {
@@ -110,7 +120,6 @@ func TestListSecrets(t *testing.T) {
 	}
 
 	filename := "test_secrets.json"
-	defer os.Remove(filename)
 
 	store, err := NewLocalSecretStore(masterKey, filename, true)
 	if err != nil {
@@ -147,5 +156,8 @@ func TestListSecrets(t *testing.T) {
 
 	if secrets[secretID2] != store.Secrets[secretID2] {
 		t.Errorf("Expected secret value %s, got %s", store.Secrets[secretID2], secrets[secretID2])
+	}
+	if err = os.Remove(filename); err != nil {
+		log.Warn().Err(err).Msg("could not close response resource")
 	}
 }

--- a/pkg/secrets/localstore_test.go
+++ b/pkg/secrets/localstore_test.go
@@ -15,6 +15,11 @@ func TestNewLocalSecretStore(t *testing.T) {
 	}
 
 	filename := "test_secrets.json"
+	defer func() {
+		if err = os.Remove(filename); err != nil {
+			log.Warn().Err(err).Msg("could not close response resource")
+		}
+	}()
 
 	store, err := NewLocalSecretStore(masterKey, filename, true)
 	if err != nil {
@@ -27,10 +32,6 @@ func TestNewLocalSecretStore(t *testing.T) {
 
 	if hex.EncodeToString(store.masterKey) != masterKey {
 		t.Errorf("Expected master key %s, got %s", masterKey, hex.EncodeToString(store.masterKey))
-	}
-
-	if err = os.Remove(filename); err != nil {
-		log.Warn().Err(err).Msg("could not close response resource")
 	}
 }
 
@@ -52,6 +53,11 @@ func TestStoreAndGetSecretByID(t *testing.T) {
 	}
 
 	filename := "test_secrets.json"
+	defer func() {
+		if err = os.Remove(filename); err != nil {
+			log.Warn().Err(err).Msg("could not close response resource")
+		}
+	}()
 
 	store, err := NewLocalSecretStore(masterKey, filename, true)
 	if err != nil {
@@ -74,10 +80,6 @@ func TestStoreAndGetSecretByID(t *testing.T) {
 	if retrievedSecret != secretValue {
 		t.Errorf("Expected secret value %s, got %s", secretValue, retrievedSecret)
 	}
-
-	if err = os.Remove(filename); err != nil {
-		log.Warn().Err(err).Msg("could not close response resource")
-	}
 }
 
 func TestStoreAndGetSecretJSON(t *testing.T) {
@@ -87,6 +89,11 @@ func TestStoreAndGetSecretJSON(t *testing.T) {
 	}
 
 	filename := "test_secrets.json"
+	defer func() {
+		if err = os.Remove(filename); err != nil {
+			log.Warn().Err(err).Msg("could not close response resource")
+		}
+	}()
 
 	store, err := NewLocalSecretStore(masterKey, filename, true)
 	if err != nil {
@@ -108,9 +115,6 @@ func TestStoreAndGetSecretJSON(t *testing.T) {
 	if retrieved != jsonSecret {
 		t.Errorf("Expected %s, got %s", jsonSecret, retrieved)
 	}
-	if err = os.Remove(filename); err != nil {
-		log.Warn().Err(err).Msg("could not close response resource")
-	}
 }
 
 func TestListSecrets(t *testing.T) {
@@ -125,6 +129,11 @@ func TestListSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create LocalSecretStore: %v", err)
 	}
+	defer func() {
+		if err = os.Remove(filename); err != nil {
+			log.Warn().Err(err).Msg("could not close response resource")
+		}
+	}()
 
 	secretID1 := "test_secret_1"
 	secretValue1 := "my_secret_value_1"


### PR DESCRIPTION
Address #86 by fixing all of the issues produced with `golangci-lint run`. This can be tested by running `magellan` like normal by following the README.