### PR TITLE
fix: default scan output to JSON

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -25,7 +25,7 @@ var (
 	include        []string
 	disableProbing bool
 	disableCache   bool
-	scanFormat     format.DataFormat
+	scanFormat     format.DataFormat = format.FORMAT_JSON
 )
 
 // The `scan` command is usually the first step to using the CLI tool.

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/OpenCHAMI/magellan/internal/format"
+)
+
+func TestScanFormatDefaultsToJSON(t *testing.T) {
+	formatFlag := ScanCmd.Flags().Lookup("format")
+	if formatFlag == nil {
+		t.Fatal("format flag is not registered")
+	}
+
+	if formatFlag.DefValue != string(format.FORMAT_JSON) {
+		t.Fatalf("format flag default = %q, want %q", formatFlag.DefValue, format.FORMAT_JSON)
+	}
+}


### PR DESCRIPTION
## Summary

- default `magellan scan` output to JSON when `--format` is omitted
- retain explicit JSON and YAML format selection
- add a regression test for the command's default format

Fixes #134.

## Testing

- `go test ./cmd ./internal/format`
- `git diff --check`

I also ran `go test ./...`. Existing emulator-dependent integration tests could not connect to the Redfish emulator in the test container, and existing `pkg` tests failed on their container network assumptions.
