### PR TITLE
fix: add hostname resolution before BMC ID mapping

### DIFF
--- a/pkg/collect.go
+++ b/pkg/collect.go
@@ -77,7 +77,13 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams) ([]map[strin
 				}
 
 				trimmedHost := strings.TrimPrefix(sr.Host, "https://")
-				uri := fmt.Sprintf("%s:%d", sr.Host, sr.Port)
+				// resolve the hostname if it exists
+				if net.ParseIP(trimmedHost) == nil {
+					addrs, err := net.LookupIP(trimmedHost)
+					if err == nil && len(addrs) > 0 {
+						trimmedHost = addrs[0].String()
+					}
+				}
 				keys := &idmap.MapperKeys{
 					IPv4Addr: trimmedHost,
 				}

--- a/pkg/collect.go
+++ b/pkg/collect.go
@@ -77,6 +77,7 @@ func CollectInventory(assets *[]RemoteAsset, params *CollectParams) ([]map[strin
 				}
 
 				trimmedHost := strings.TrimPrefix(sr.Host, "https://")
+				uri := fmt.Sprintf("%s:%d", sr.Host, sr.Port)
 				// resolve the hostname if it exists
 				if net.ParseIP(trimmedHost) == nil {
 					addrs, err := net.LookupIP(trimmedHost)


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [X] My code follows the style guidelines of this project  
- [X] I have added/updated comments where needed  
- [X] I have added tests that prove my fix is effective or my feature works  
- [X] I have run `make test` (or equivalent) locally and all tests pass  
- [X] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [X] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

This PR adds hostname resolution before BMC ID mappings occur in `pkg/collect.go`. This should allow `collect` to run using hostnames like `https://x8000c0s1b1`.

Fixes #137 

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
