### PR TITLE
fix(version): report accurate and aligned build metadata

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,7 @@ builds:
     # export BUILD_USER=$(whoami)
     ldflags:
       - "-X github.com/OpenCHAMI/magellan/internal/version.GitCommit={{ .Commit }} \
-        -X github.com/OpenCHAMI/magellan/internal/version.BuildTime={{ .Timestamp }} \
+        -X github.com/OpenCHAMI/magellan/internal/version.BuildTime={{ .Date }} \
         -X github.com/OpenCHAMI/magellan/internal/version.Version={{ .Version }} \
         -X github.com/OpenCHAMI/magellan/internal/version.GitBranch={{ .Branch }} \
         -X github.com/OpenCHAMI/magellan/internal/version.GitTag={{ .Tag }} \

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ BUILD      ?= $(shell $(GIT) rev-parse --short HEAD)
 GIT_BRANCH ?= $(shell $(GIT) rev-parse --abbrev-ref HEAD)
 GIT_TAG    ?= $(shell $(GIT) describe --tags --abbrev=0 2>/dev/null || echo "unknown")
 GIT_STATE  ?= $(shell if $(GIT) diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi)
+BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 BUILD_HOST ?= $(shell $(HOSTCMD))
 GO_VERSION ?= $(shell $(GO) env GOVERSION)
 BUILD_USER ?= $(shell whoami)
@@ -75,7 +76,7 @@ CONTAINER_TAG ?= latest
 FQCN          ?= ghcr.io/openchami/$(NAME):$(CONTAINER_TAG)
 LDFLAGS := -s \
 	   -X $(IMPORT)internal/version.GitCommit=$(BUILD) \
-	   -X $(IMPORT)internal/version.BuildTime=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
+	   -X $(IMPORT)internal/version.BuildTime=$(BUILD_TIME) \
 	   -X $(IMPORT)internal/version.Version=$(VERSION) \
 	   -X $(IMPORT)internal/version.GitBranch=$(GIT_BRANCH) \
 	   -X $(IMPORT)internal/version.GitTag=$(GIT_TAG) \

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 
 require (
 	github.com/Cray-HPE/hms-xname v1.4.0
-	github.com/ncruces/go-strftime v1.0.0
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.12.1
@@ -34,6 +33,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,9 +2,6 @@ package version
 
 import (
 	"fmt"
-	"time"
-
-	"github.com/ncruces/go-strftime"
 )
 
 // GitCommit stores the latest Git commit hash.
@@ -13,7 +10,7 @@ var GitCommit string = "unknown"
 
 // BuildTime stores the build timestamp in UTC.
 // Set via -ldflags "-X github.com/OpenCHAMI/magellan/internal/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-var BuildTime string = strftime.Format("%Y-%m-%dT%H:%M:%SZ", time.Now())
+var BuildTime string = "unknown"
 
 // Version indicates the version of the binary, such as a release number or semantic version.
 // Set via -ldflags "-X github.com/OpenCHAMI/magellan/internal/version.Version=v1.0.0"
@@ -46,15 +43,28 @@ var BuildUser string = "unknown"
 
 // PrintVersionInfo outputs all versioning information for troubleshooting or version checks.
 func PrintVersionInfo() {
-	fmt.Printf("Version: %s\n", Version)
-	fmt.Printf("Git Commit: %s\n", GitCommit)
-	fmt.Printf("Build Time: %s\n", BuildTime)
-	fmt.Printf("Git Branch: %s\n", GitBranch)
-	fmt.Printf("Git Tag: %s\n", GitTag)
-	fmt.Printf("Git State: %s\n", GitState)
-	fmt.Printf("Build Host: %s\n", BuildHost)
-	fmt.Printf("Go Version: %s\n", GoVersion)
-	fmt.Printf("Build User: %s\n", BuildUser)
+	fmt.Print(versionInfoTable())
+}
+
+func versionInfoTable() string {
+	return fmt.Sprintf(`%-11s %s
+%-11s %s
+%-11s %s
+%-11s %s
+%-11s %s
+%-11s %s
+%-11s %s
+%-11s %s
+%-11s %s
+`, "Version:", Version,
+		"Git Commit:", GitCommit,
+		"Build Time:", BuildTime,
+		"Git Branch:", GitBranch,
+		"Git Tag:", GitTag,
+		"Git State:", GitState,
+		"Build Host:", BuildHost,
+		"Go Version:", GoVersion,
+		"Build User:", BuildUser)
 }
 
 func VersionInfo() string {

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -14,3 +14,20 @@ func TestVersionInfo(t *testing.T) {
 	require.Contains(t, got, "v1.2.3")
 	require.Contains(t, got, "abc123")
 }
+
+func TestBuildTimeDefaultsToUnknown(t *testing.T) {
+	require.Equal(t, "unknown", BuildTime)
+}
+
+func TestVersionInfoTableAlignsValues(t *testing.T) {
+	require.Equal(t, `Version:    unknown
+Git Commit: unknown
+Build Time: unknown
+Git Branch: unknown
+Git Tag:    unknown
+Git State:  unknown
+Build Host: unknown
+Go Version: unknown
+Build User: unknown
+`, versionInfoTable())
+}


### PR DESCRIPTION
### Description

Inject an RFC3339 build timestamp through Make and Goreleaser instead of calculating it at runtime. Default missing build metadata to unknown, align version command output for readability, and add regression coverage.

Fixes #182 

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass
- [x] I have updated the relevant documentation (CLI examples, man pages, README, other docs, etc.)
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Dependency update

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
